### PR TITLE
DICOM extractor rejects pydicom types

### DIFF
--- a/datalad_neuroimaging/extractors/tests/test_dicom.py
+++ b/datalad_neuroimaging/extractors/tests/test_dicom.py
@@ -6,7 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Test audio extractor"""
+"""Test DICOM extractor"""
 
 from datalad.tests.utils import SkipTest
 try:
@@ -48,6 +48,11 @@ def test_dicom(path):
     # no point in testing ALL keys, but we got plenty
     assert(len(meta.keys()) > 70)
     eq_(meta['SeriesDate'], '20070205')
+    # make sure we have PatientName -- this is not using a basic data type, but
+    # dicom.valuerep.PersonName3 -- conversion should have handled that
+    # we can only test if the key is there, the source dicom has an empty
+    # string as value
+    eq_(meta['PatientName'], '')
 
     # now ask for the dataset metadata, which should have both the unique props
     # and a list of imageseries (one in this case, but a list)


### PR DESCRIPTION
When reading a file from https://github.com/datalad/example-dicom-structural, the DICOM extractor's `_is_good_type` returns `False` for the "PatientName".

```
In [3]: s = pydicom.read_file('dicoms/N2D_0001.dcm', stop_before_pixels=True)

In [4]: import datalad_neuroimaging.extractors.dicom

In [5]: datalad_neuroimaging.extractors.dicom._struct2dict(s)
Out[5]: 
{'AccessionNumber': '',
 'AcquisitionDate': '20130717',
 'AcquisitionNumber': '1',
 'AcquisitionTime': '132518',
 'BitsAllocated': 16,
 'BitsStored': 16,
 'Columns': 274,
 'FrameOfReferenceUID': '1.2.826.0.1.3680043.2.1143.6856184167807409206647724161920598374',
 'HighBit': 15,
 'InstanceNumber': '1',
 'InstitutionName': '',
 'Manufacturer': 'BIOLAB',
 'ManufacturerModelName': 'nifti2dicom',
 'Modality': 'MR',
 'OtherPatientIDs': '',
 'PatientAge': '42',
 'PatientBirthDate': '19660101',
 'PatientID': 'sub02',
 'PatientSex': 'F',
 'PatientWeight': "75",
 'PhotometricInterpretation': 'MONOCHROME2',
 'PixelRepresentation': 1,
 'PregnancyStatus': 4,
 'ProtocolName': 'anat-T1w',
 'RescaleIntercept': "0",
 'RescaleSlope': "1",
 'RescaleType': 'US',
 'Rows': 384,
 'SOPClassUID': '1.2.840.10008.5.1.4.1.1.4',
 'SOPInstanceUID': '1.2.826.0.1.3680043.2.1143.1590429688519720198888333603882344634',
 'SamplesPerPixel': 1,
 'SeriesDate': '20130717',
 'SeriesDescription': 'anat-T1w',
 'SeriesInstanceUID': '1.2.826.0.1.3680043.2.1143.515404396022363061013111326823367652',
 'SeriesNumber': '401',
 'SeriesTime': '142035.93000',
 'SliceThickness': "0.666666686534882",
 'SoftwareVersions': '0.4.11',
 'SpacingBetweenSlices': "0.666666686534882",
 'StudyDate': '20130717',
 'StudyDescription': 'Hanke_Stadler^0024_transrep',
 'StudyID': '433724515',
 'StudyInstanceUID': '1.2.826.0.1.3680043.2.1143.2592092611698916978113112155415165916',
 'StudyTime': '141500'}

In [6]: s.PatientName
Out[6]: 'Jane_Doe'

In [7]: datalad_neuroimaging.extractors.dicom._is_good_type(s.PatientName)
Out[7]: False

In [8]: type(s.PatientName)
Out[8]: pydicom.valuerep.PersonName3
```

@yarikoptic : Since this routine (`_is_good_type`) was written by you - any suggestions on how to solve this?
