### PR TITLE
Fish helpers out of #7 to generate a BIDS dataset from DICOM as a test fixture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "datalad_neuroimaging/tests/data/dicoms/structural"]
 	path = datalad_neuroimaging/tests/data/dicoms/structural
 	url = https://github.com/datalad/example-dicom-structural.git
+[submodule "datalad_neuroimaging/tests/data/dicoms/functional"]
+	path = datalad_neuroimaging/tests/data/dicoms/functional
+	url = https://github.com/datalad/example-dicom-functional.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,10 @@ install:
   - pip install -r requirements.txt
   - pip install 'sphinx>=1.6.2'
   - pip install 'sphinx-rtd-theme'
-  # bleeding edge pybids fix
-  - pip install 'scipy'
+  # heudiconv for conversion testing:
+  - travis_retry sudo eatmydata apt-get install dcm2niix
+  - pip install git+https://github.com/mvdoc/dcmstack@bf/importsys
+  - pip install git+https://github.com/bpoldrack/heudiconv.git@cbbs-imaging
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
 

--- a/datalad_neuroimaging/tests/test_dicomconv.py
+++ b/datalad_neuroimaging/tests/test_dicomconv.py
@@ -16,9 +16,11 @@ from datalad.api import Dataset
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import eq_
 
 import datalad_neuroimaging
 from datalad_neuroimaging.tests.utils import get_dicom_dataset
+from datalad_neuroimaging.tests.utils import get_bids_dataset
 
 
 @with_tempfile
@@ -31,3 +33,9 @@ def test_dicom_metadata_aggregation(path):
     res = ds.metadata(get_aggregates=True)
     assert_result_count(res, 2)
     assert_result_count(res, 1, path=opj(ds.path, 'acq100'))
+
+
+def test_validate_bids_fixture():
+    bids_ds = get_bids_dataset()
+    # dicom source dataset is absent
+    eq_(len(bids_ds.subdatasets(fulfilled=True, return_type='list')), 0)

--- a/datalad_neuroimaging/tests/test_dicomconv.py
+++ b/datalad_neuroimaging/tests/test_dicomconv.py
@@ -10,29 +10,15 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test DICOM conversion tools"""
 
-
-from os.path import pardir
-from os.path import dirname
-from os.path import normpath
 from os.path import join as opj
 
-import datalad_neuroimaging
 from datalad.api import Dataset
-from datalad.api import install
-
+from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import assert_result_count
 
-
-def get_dicom_dataset(flavor):
-    modpath = dirname(datalad_neuroimaging.__file__)
-    ds = install(
-        dataset=normpath(opj(modpath, pardir)),
-        path=opj(modpath, 'tests', 'data', 'dicoms', flavor))
-    # fail on any "surprising" changes made to this dataset
-    ok_clean_git(ds.path)
-    return ds
+import datalad_neuroimaging
+from datalad_neuroimaging.tests.utils import get_dicom_dataset
 
 
 @with_tempfile

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -1,0 +1,26 @@
+from os.path import dirname, normpath, join as opj, pardir
+
+from datalad.api import Dataset
+from datalad.coreapi import install
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import with_tempfile
+
+import datalad_neuroimaging
+
+
+def get_dicom_dataset(flavor):
+    modpath = dirname(datalad_neuroimaging.__file__)
+    ds = install(
+        dataset=normpath(opj(modpath, pardir)),
+        path=opj(modpath, 'tests', 'data', 'dicoms', flavor))
+    # fail on any "surprising" changes made to this dataset
+    ok_clean_git(ds.path)
+    return ds
+
+
+def create_dicom_tarball(flavor, path):
+    import tarfile
+    ds = get_dicom_dataset(flavor=flavor)
+    with tarfile.open(path, "w:gz") as tar:
+        tar.add(ds.path)
+    return path

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -3,19 +3,96 @@ from os.path import dirname, normpath, join as opj, pardir
 from datalad.api import Dataset
 from datalad.coreapi import install
 from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import with_tempfile
 
 import datalad_neuroimaging
+_modpath = dirname(datalad_neuroimaging.__file__)
 
 
 def get_dicom_dataset(flavor):
-    modpath = dirname(datalad_neuroimaging.__file__)
     ds = install(
-        dataset=normpath(opj(modpath, pardir)),
-        path=opj(modpath, 'tests', 'data', 'dicoms', flavor))
+        dataset=normpath(opj(_modpath, pardir)),
+        path=opj(_modpath, 'tests', 'data', 'dicoms', flavor))
     # fail on any "surprising" changes made to this dataset
     ok_clean_git(ds.path)
     return ds
+
+
+def get_bids_dataset():
+    bids_ds = Dataset(path=opj(_modpath, 'tests', 'data', 'bids'))
+    if bids_ds.is_installed():
+        return bids_ds
+    # make one
+    dicom_ds = get_dicom_dataset('structural')
+    bids_ds.create()
+    # place dicoms in the mandated shadow tree
+    dicom_ds = bids_ds.install(
+        source=dicom_ds,
+        path=opj('sourcedata', 'sub-02', 'ses-structural'),
+        reckless=True)
+    # dicom dataset is preconfigured for metadata extraction
+    bids_ds.aggregate_metadata(recursive=True)
+    ok_clean_git(dicom_ds.path)
+    # pull subject ID from metadata
+    res = bids_ds.metadata(
+        dicom_ds.path, reporton='datasets', return_type='item-or-list',
+        result_renderer='disabled')
+    subj_id = res['metadata']['dicom']['Series'][0]['PatientID']
+    # prepare for incoming BIDS metadata that we will want to keep in
+    # Git -- templates would be awesome!
+    with open(opj(bids_ds.path, '.gitattributes'), 'a') as ga:
+        # except for hand-picked global metadata, we want anything
+        # to go into the annex to be able to retract files after
+        # publication
+        ga.write('** annex.largefiles=anything\n')
+        for fn in ('CHANGES', 'README', 'dataset_description.json'):
+            # but not these
+            ga.write('{} annex.largefiles=nothing\n'.format(fn))
+    bids_ds.add('.gitattributes', to_git=True,
+                message='Initial annex entry configuration')
+    ok_clean_git(bids_ds.path)
+    # conversion to BIDS
+    from mock import patch
+    import heudiconv.cli.run
+    heudiconv.cli.run.main([
+        '-f', 'reproin',
+        # TODO fix DICOMs to not have a 'sub' prefix
+        '-s', subj_id[3:],
+        '-c' 'dcm2niix',
+        '-b',
+        '-o', bids_ds.path,
+        '-l', '',
+        '--files', opj(dicom_ds.path, 'dicoms'),
+    ])
+    # cleanup: with heudiconv -b we can dicom tarballs per sequence
+    # while this is nice, we already have a subdataset with dicoms
+    # and don't need two, and in the general case people will
+    # rarely by able to share these, and they require additional
+    # storage
+    # XXX kill them for now
+    # TODO heudoconv should have a switch to prevent this tarball
+    # generation
+    import shutil
+    import os
+    shutil.rmtree(opj(
+        bids_ds.path, 'sourcedata', 'sub-02', 'anat'))
+    os.remove(opj(
+        bids_ds.path, 'sourcedata', 'README'))
+    # TODO decide on the fate of .heudiconv/
+    shutil.rmtree(opj(
+        bids_ds.path, '.heudiconv'))
+    # and commit the rest
+    bids_ds.add('.', message="Add BIDS-converted content")
+    bids_ds.config.add('datalad.metadata.nativetype', 'bids',
+                       where='dataset', reload=False)
+    bids_ds.config.add('datalad.metadata.nativetype', 'nifti1',
+                       where='dataset', reload=True)
+    bids_ds.save(message='Metadata type config')
+    # loose dicom dataset
+    bids_ds.uninstall(dicom_ds.path, check=False)
+    # no need for recursion, we already have the dicom dataset's
+    # stuff on record
+    bids_ds.aggregate_metadata(recursive=False, incremental=True)
+    ok_clean_git(bids_ds.path)
 
 
 def create_dicom_tarball(flavor, path):

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -86,7 +86,9 @@ def get_bids_dataset():
                        where='dataset', reload=False)
     bids_ds.config.add('datalad.metadata.nativetype', 'nifti1',
                        where='dataset', reload=True)
-    bids_ds.save(message='Metadata type config')
+    # XXX need to give path specifically to make it work in direct mode
+    #bids_ds.save(message='Metadata type config')
+    bids_ds.add('.', message='Metadata type config')
     # loose dicom dataset
     bids_ds.uninstall(dicom_ds.path, check=False)
     # no need for recursion, we already have the dicom dataset's

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -93,6 +93,7 @@ def get_bids_dataset():
     # stuff on record
     bids_ds.aggregate_metadata(recursive=False, incremental=True)
     ok_clean_git(bids_ds.path)
+    return bids_ds
 
 
 def create_dicom_tarball(flavor, path):

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -22,19 +22,19 @@ def get_bids_dataset():
     if bids_ds.is_installed():
         return bids_ds
     # make one
-    dicom_ds = get_dicom_dataset('structural')
+    structdicom_ds = get_dicom_dataset('structural')
     bids_ds.create()
     # place dicoms in the mandated shadow tree
-    dicom_ds = bids_ds.install(
-        source=dicom_ds,
+    structdicom_ds = bids_ds.install(
+        source=structdicom_ds,
         path=opj('sourcedata', 'sub-02', 'ses-structural'),
         reckless=True)
     # dicom dataset is preconfigured for metadata extraction
     bids_ds.aggregate_metadata(recursive=True)
-    ok_clean_git(dicom_ds.path)
+    ok_clean_git(structdicom_ds.path)
     # pull subject ID from metadata
     res = bids_ds.metadata(
-        dicom_ds.path, reporton='datasets', return_type='item-or-list',
+        structdicom_ds.path, reporton='datasets', return_type='item-or-list',
         result_renderer='disabled')
     subj_id = res['metadata']['dicom']['Series'][0]['PatientID']
     # prepare for incoming BIDS metadata that we will want to keep in
@@ -61,7 +61,7 @@ def get_bids_dataset():
         '-b',
         '-o', bids_ds.path,
         '-l', '',
-        '--files', opj(dicom_ds.path, 'dicoms'),
+        '--files', opj(structdicom_ds.path, 'dicoms'),
     ])
     # cleanup: with heudiconv -b we can dicom tarballs per sequence
     # while this is nice, we already have a subdataset with dicoms
@@ -90,7 +90,7 @@ def get_bids_dataset():
     #bids_ds.save(message='Metadata type config')
     bids_ds.add('.', message='Metadata type config')
     # loose dicom dataset
-    bids_ds.uninstall(dicom_ds.path, check=False)
+    bids_ds.uninstall(structdicom_ds.path, check=False)
     # no need for recursion, we already have the dicom dataset's
     # stuff on record
     bids_ds.aggregate_metadata(recursive=False, incremental=True)


### PR DESCRIPTION
This will be instrumental for testing anything related to metadata. The current setup relies on the `///` which is outdated, or toy examples with limited scope. We need a full featured dataset with all bells and whistles that we can have.

- [x] linked DICOM subdataset
- [x] bids, nifti1, dicom metadata accessible
- [x] all but core metadata files in the annex
- [ ]  multi-session