### PR TITLE
BIDS extractor hides any issue with pybids

### DIFF
--- a/datalad_neuroimaging/extractors/bids.py
+++ b/datalad_neuroimaging/extractors/bids.py
@@ -129,6 +129,8 @@ class MetadataExtractor(BaseMetadataExtractor):
                 for rx, info in yield_participant_info(bids):
                     path_props[rx] = {'subject': info}
             except Exception as exc:
+                if isinstance(exc, ImportError):
+                    raise exc
                 lgr.warning(
                     "Failed to load participants info due to: %s. Skipping the rest of file",
                     exc_str(exc)


### PR DESCRIPTION
An installation was missing scipy (because https://github.com/INCF/pybids/issues/174), and suddenly the metadata changed structure. I was not aware, because I made it ignore all errors, including ImportErrors. not good.