### PR TITLE
BF: make compatible with pybids 0.6.4

### DIFF
--- a/datalad_neuroimaging/extractors/bids.py
+++ b/datalad_neuroimaging/extractors/bids.py
@@ -68,14 +68,12 @@ class MetadataExtractor(BaseMetadataExtractor):
         if not exists(opj(self.ds.path, self._dsdescr_fname)):
             return {}, []
 
-        bids = BIDSLayout(
-            self.ds.path,
-            config=[
-                'bids', (
-                    'derivatives',
-                    'derivatives' if exists(opj(self.ds.path, 'derivatives')) else curdir
-                )],
-        )
+        paths = [(self.ds.path, 'bids')]
+        derivs_path = opj(self.ds.path, 'derivatives')
+        if exists(opj(self.ds.path, 'derivatives')):
+            paths.append((derivs_dir, ['bids', 'derivatives']))
+
+        bids = BIDSLayout(paths)
         dsmeta = self._get_dsmeta(bids)
 
         if not content:

--- a/datalad_neuroimaging/extractors/tests/test_bids.py
+++ b/datalad_neuroimaging/extractors/tests/test_bids.py
@@ -96,6 +96,7 @@ def test_get_metadata(path):
 @with_tree(tree={'dataset_description.json': """
 {
     "Name": "test",
+    "BIDSVersion": "1.0.0-rc3",
     "Description": "Some description"
 }
 """,
@@ -113,7 +114,8 @@ def test_get_metadata_with_description_and_README(path):
         dump,
         """\
 {
-  "conformsto": "http://bids.neuroimaging.io",
+  "BIDSVersion": "1.0.0-rc3",
+  "conformsto": "http://bids.neuroimaging.io/bids_spec1.0.0-rc3.pdf",
   "description": "Some description",
   "name": "test"
 }""")
@@ -123,7 +125,8 @@ def test_get_metadata_with_description_and_README(path):
 # https://github.com/datalad/datalad/issues/1138
 @with_tree(tree={'dataset_description.json': """
 {
-    "Name": "test"
+    "Name": "test",
+    "BIDSVersion": "1.0.0-rc3"
 }
 """,
                  'README': u"""
@@ -139,7 +142,8 @@ def test_get_metadata_with_README(path):
         dump,
         u"""\
 {
-  "conformsto": "http://bids.neuroimaging.io",
+  "BIDSVersion": "1.0.0-rc3",
+  "conformsto": "http://bids.neuroimaging.io/bids_spec1.0.0-rc3.pdf",
   "description": "A very detailed\\ndescription с юникодом",
   "name": "test"
 }""")

--- a/docs/examples/nipype_workshop_dataset.sh
+++ b/docs/examples/nipype_workshop_dataset.sh
@@ -191,7 +191,7 @@ datalad add -d . nipype-2017
 #%
 
 # created some dataset_description.json (following BIDS format lazy me)
-echo '{"Name": "Datasets for various workshops"}' > dataset_description.json
+echo -e '{"Name": "Datasets for various workshops",\n "BIDSVersion": "1.0.0"}' > dataset_description.json
 # and tell datalad that this is using the BIDS metadata standard
 git config --file .datalad/config --add datalad.metadata.nativetype bids
 # add that file to git

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'datalad[full]>=0.10.0.rc1',
         #'datalad-webapp',
         'pydicom',  # DICOM metadata
-        'pybids[analysis]>=0.5.1',  # BIDS metadata
+        'pybids>=0.6.4',  # BIDS metadata
         'nibabel',  # NIfTI metadata
         'pandas',  # bids2scidata export
     ],


### PR DESCRIPTION
in 0.6 pybids

- dropped installation schemes
- broke API

may be https://github.com/INCF/pybids/pull/218/files would return installation
scheme to improve compatibility, but I guess we should no longer rely on
it anyways