### PR TITLE
NF: NIDMResults metadata extractor draft

### DIFF
--- a/datalad_neuroimaging/extractors/nidmresults.py
+++ b/datalad_neuroimaging/extractors/nidmresults.py
@@ -12,6 +12,7 @@ import logging
 import os.path as op
 from zipfile import ZipFile
 
+from datalad.dochelpers import exc_str
 from datalad.support import json_py
 
 lgr = logging.getLogger('datalad.metadata.extractors.nidmresults')
@@ -21,19 +22,13 @@ from datalad.metadata.extractors.base import BaseMetadataExtractor
 
 
 class MetadataExtractor(BaseMetadataExtractor):
-    # this extractor instance knows:
-    #   self.ds -- an instance of the dataset it shall operate on
-    #   self.paths -- a list of paths within the dataset from which
-    #                 metadata should be extracted, pretty much up to
-    #                 the extractor if those those paths are used. They are
-    #                 provided to avoid duplicate directory tree traversal
-    #                 when multiples extractors are executed
+
     def get_metadata(self, dataset, content):
         # function gets two flags indicating whether to extract dataset-global
         # and/or content metadata
 
         # function returns a tuple
-        # item 1: dict with dataset-global metadata (e.g. a NIDM blob)
+        # item 1: dict with dataset-global metadata
         #         should come with a JSON-LD context for that blob, context
         #         is preserved during aggregation
         # item 2: generator yielding metadata dicts for each (file) path in the
@@ -41,17 +36,34 @@ class MetadataExtractor(BaseMetadataExtractor):
         #         JSON-LD context is assigned to the metadata dict, hence file metadata
         #         should not be returned with individual/repeated contexts, but rather
         #         the dataset-global context should provide all definitions
-        nidmblobs = {f[:-9]: f for f in self.paths if f.endswith('.nidm.zip')}
 
-        metadata = {}
+        # TODO we could report basic info on the dataset level too (maybe at least
+        # number of analyses reported)
+        # TODO agree on, and report a @context for the packs that are reported as content
+        # metadata
+        return \
+            {}, \
+            (self._yield_nidm_blobs() if content else [])
 
-        for name, path in nidmblobs.items():
+    def _yield_nidm_blobs(self):
+        for packfile in [f for f in self.paths if f.endswith('.nidm.zip')]:
             nidmblob = None
-            with ZipFile(op.join(self.ds.path, path), 'r') as z:
-                nidmblob = z.read('nidm_minimal.json')
-            nidmblob = json_py.loads(nidmblob)
-            if isinstance(nidmblob, list) and len(nidmblob) == 1:
-                nidmblob = nidmblob[0]
-            metadata[name] = nidmblob
-
-        return metadata, []
+            try:
+                packabspath = op.join(self.ds.path, packfile)
+                with ZipFile(packabspath, 'r') as z:
+                    nidmblob = z.read('nidm_minimal.json')
+                nidmblob = json_py.loads(nidmblob)
+            except Exception as e:
+                lgr.warning(
+                    "Failed to load NIDM results pack at %s: %s",
+                    packabspath, exc_str(e))
+                continue
+            if isinstance(nidmblob, list):
+                if len(nidmblob) == 1:
+                    nidmblob = nidmblob[0]
+                else:
+                    lgr.warning(
+                        "Found more then one NIDM result structure in pack at %s, cannot report that.",
+                        packabspath)
+                    continue
+            yield packfile, nidmblob

--- a/datalad_neuroimaging/extractors/nidmresults.py
+++ b/datalad_neuroimaging/extractors/nidmresults.py
@@ -48,7 +48,7 @@ class MetadataExtractor(BaseMetadataExtractor):
         for name, path in nidmblobs.items():
             nidmblob = None
             with ZipFile(op.join(self.ds.path, path), 'r') as z:
-                nidmblob = z.read('nidm.jsonld')
+                nidmblob = z.read('nidm_minimal.json')
             nidmblob = json_py.loads(nidmblob)
             if isinstance(nidmblob, list) and len(nidmblob) == 1:
                 nidmblob = nidmblob[0]

--- a/datalad_neuroimaging/extractors/nidmresults.py
+++ b/datalad_neuroimaging/extractors/nidmresults.py
@@ -1,0 +1,57 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""NIDM metadata extractor"""
+
+import logging
+import os.path as op
+from zipfile import ZipFile
+
+from datalad.support import json_py
+
+lgr = logging.getLogger('datalad.metadata.extractors.nidmresults')
+
+from datalad.metadata.definitions import vocabulary_id
+from datalad.metadata.extractors.base import BaseMetadataExtractor
+
+
+class MetadataExtractor(BaseMetadataExtractor):
+    # this extractor instance knows:
+    #   self.ds -- an instance of the dataset it shall operate on
+    #   self.paths -- a list of paths within the dataset from which
+    #                 metadata should be extracted, pretty much up to
+    #                 the extractor if those those paths are used. They are
+    #                 provided to avoid duplicate directory tree traversal
+    #                 when multiples extractors are executed
+    def get_metadata(self, dataset, content):
+        # function gets two flags indicating whether to extract dataset-global
+        # and/or content metadata
+
+        # function returns a tuple
+        # item 1: dict with dataset-global metadata (e.g. a NIDM blob)
+        #         should come with a JSON-LD context for that blob, context
+        #         is preserved during aggregation
+        # item 2: generator yielding metadata dicts for each (file) path in the
+        #         dataset. When querying aggregated metadata for a file, the dataset's
+        #         JSON-LD context is assigned to the metadata dict, hence file metadata
+        #         should not be returned with individual/repeated contexts, but rather
+        #         the dataset-global context should provide all definitions
+        nidmblobs = {f[:-9]: f for f in self.paths if f.endswith('.nidm.zip')}
+
+        metadata = {}
+
+        for name, path in nidmblobs.items():
+            nidmblob = None
+            with ZipFile(op.join(self.ds.path, path), 'r') as z:
+                nidmblob = z.read('nidm.jsonld')
+            nidmblob = json_py.loads(nidmblob)
+            if isinstance(nidmblob, list) and len(nidmblob) == 1:
+                nidmblob = nidmblob[0]
+            metadata[name] = nidmblob
+
+        return metadata, []

--- a/datalad_neuroimaging/extractors/nidmresults.py
+++ b/datalad_neuroimaging/extractors/nidmresults.py
@@ -74,7 +74,7 @@ class MetadataExtractor(BaseMetadataExtractor):
             context_url = nidmblob.get('@context', None)
             # TODO this conditional may go away if the final NIDM metadata concept
             # includes the full context and does not use a URL reference
-            if context_url:
+            if context_url and not isinstance(context_url, dict):
                 # context might be a URL, in which case we want to capture the
                 # actual context behind that URL, even if it is just the first
                 # level

--- a/datalad_neuroimaging/extractors/tests/test_nidmresults.py
+++ b/datalad_neuroimaging/extractors/tests/test_nidmresults.py
@@ -1,0 +1,182 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test NIDM results extractor"""
+
+from shutil import copy
+from shutil import make_archive
+import os.path as op
+from datalad.api import Dataset
+from datalad.tests.utils import with_tree
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import assert_status
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_result_count
+
+
+# TODO update when format changes to a compacted JSON-LD form
+example_metadata = """\
+{
+    "NIDMResultsExporter_type": "spm_results_nidm",
+    "NIDMResultsExporter_softwareVersion": "12.7057",
+    "NIDMResults_version": "1.3.0",
+    "NeuroimagingAnalysisSoftware_type": "scr_SPM",
+    "NeuroimagingAnalysisSoftware_label": "SPM",
+    "NeuroimagingAnalysisSoftware_softwareVersion": "12.7219",
+    "ImagingInstrument_type": "nlx_MagneticResonanceImagingScanner",
+    "Data_grandMeanScaling": true,
+    "Data_targetIntensity": 100,
+    "Data_hasMRIProtocol": "nlx_FunctionalMRIProtocol",
+    "ParameterEstimateMaps": [
+        "/test/data/nidmresults-examples/spm_full_example001/beta_0001.nii",
+        "/test/data/nidmresults-examples/spm_full_example001/beta_0002.nii"
+    ],
+    "ResidualMeanSquaresMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/ResMS.nii",
+    "ReselsPerVoxelMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/RPV.nii",
+    "Contrasts": {
+        "StatisticMap_contrastName": "passive listening > rest",
+        "ContrastWeightMatrix_value": [1,0],
+        "StatisticMap_statisticType": "obo_TStatistic",
+        "StatisticMap_errorDegreesOfFreedom": 83.9999999999599,
+        "ContrastStandardErrorMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/ContrastStandardError.nii.gz"
+    },
+    "ClusterDefinitionCriteria_hasConnectivityCriterion": "nidm_voxel18connected",
+    "PeakDefinitionCriteria_minDistanceBetweenPeaks": 8,
+    "PeakDefinitionCriteria_maxNumberOfPeaksPerCluster": 3,
+    "Inferences": {
+        "HeightThreshold_type": "obo_FWERAdjustedPValue",
+        "HeightThreshold_value": 0.0499999999999976,
+        "ExtentThreshold_type": "obo_Statistic",
+        "ExtentThreshold_clusterSizeInVoxels": 0,
+        "ExtentThreshold_clusterSizeInResels": 0,
+        "HeightThreshold_equivalentThreshold": [
+            {
+                "HeightThreshold_type": "obo_Statistic",
+                "HeightThreshold_value": 4.852417456895391
+            },
+            {
+                "HeightThreshold_type": "nidm_PValueUncorrected",
+                "HeightThreshold_value": 2.7772578456986e-06
+            }
+        ],
+        "ExtentThreshold_equivalentThreshold": [
+            {
+                "ExtentThreshold_type": "obo_FWERAdjustedPValue",
+                "ExtentThreshold_value": 1
+            },
+            {
+                "ExtentThreshold_type": "nidm_PValueUncorrected",
+                "ExtentThreshold_value": 1
+            }
+        ],
+        "Inference_hasAlternativeHypothesis": "nidm_OneTailedTest",
+        "StatisticMap_contrastName": ["passive listening > rest"],
+        "ExcursionSetMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/ExcursionSet.nii.gz",
+        "ExcursionSetMap_numberOfSupraThresholdClusters": 5,
+        "ExcursionSetMap_pValue": 2.835106815979316e-09,
+        "ClusterLabelsMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/ClusterLabels.nii.gz",
+        "ExcursionSetMap_hasMaximumIntensityProjection": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/MaximumIntensityProjection.png",
+        "Clusters": [
+            {
+                "SupraThresholdCluster_clusterSizeInVoxels": 839,
+                "SupraThresholdCluster_clusterSizeInResels": 6.312656968091135,
+                "SupraThresholdCluster_pValueUncorrected": 3.558968244804772e-19,
+                "SupraThresholdCluster_pValueFWER": 0,
+                "SupraThresholdCluster_qValueFDR": 1.779484122402386e-18,
+                "Peaks": [
+                    {
+                        "Peak_value": 17.5207633972168,
+                        "Coordinate_coordinateVector": [-60,-25,11],
+                        "Peak_pValueUncorrected": 4.440892098500626e-16,
+                        "Peak_equivalentZStatistic": null,
+                        "Peak_pValueFWER": 0,
+                        "Peak_qValueFDR": 1.191565917138381e-11
+                    },
+                    {
+                        "Peak_value": 13.03214073181152,
+                        "Coordinate_coordinateVector": [-42,-31,11],
+                        "Peak_pValueUncorrected": 4.440892098500626e-16,
+                        "Peak_equivalentZStatistic": null,
+                        "Peak_pValueFWER": 0,
+                        "Peak_qValueFDR": 1.191565917138381e-11
+                    },
+                    {
+                        "Peak_value": 10.28560161590576,
+                        "Coordinate_coordinateVector": [-66,-31,-1],
+                        "Peak_pValueUncorrected": 4.440892098500626e-16,
+                        "Peak_equivalentZStatistic": null,
+                        "Peak_pValueFWER": 7.69451169446711e-12,
+                        "Peak_qValueFDR": 6.841212602749916e-10
+                    }
+                ]
+            },
+            {
+                "SupraThresholdCluster_clusterSizeInVoxels": 695,
+                "SupraThresholdCluster_clusterSizeInResels": 5.229197369276923,
+                "SupraThresholdCluster_pValueUncorrected": 5.342802826320728e-17,
+                "SupraThresholdCluster_pValueFWER": 0,
+                "SupraThresholdCluster_qValueFDR": 1.335700706580182e-16,
+                "Peaks": [
+                    {
+                        "Peak_value": 13.54255771636963,
+                        "Coordinate_coordinateVector": [63,-13,-4],
+                        "Peak_pValueUncorrected": 4.440892098500626e-16,
+                        "Peak_equivalentZStatistic": null,
+                        "Peak_pValueFWER": 0,
+                        "Peak_qValueFDR": 1.191565917138381e-11
+                    },
+                    {
+                        "Peak_value": 12.47287178039551,
+                        "Coordinate_coordinateVector": [60,-22,11],
+                        "Peak_pValueUncorrected": 4.440892098500626e-16,
+                        "Peak_equivalentZStatistic": null,
+                        "Peak_pValueFWER": 0,
+                        "Peak_qValueFDR": 1.191565917138381e-11
+                    }
+                ]
+            }
+        ]
+    }
+}
+"""
+
+
+@with_tree(tree={'nidm_minimal.json': example_metadata})
+@with_tempfile(mkdir=True)
+def test_nidm(packpath, dspath):
+    # create a fake NIDMresult pack
+    ds = Dataset(dspath).create()
+    make_archive(
+        op.join(dspath, 'myfake.nidm'),
+        'zip',
+        packpath)
+    ds.add('.')
+    ds.run_procedure(['cfg_metadatatypes', 'nidmresults'])
+    ok_clean_git(dspath)
+
+    # engage the extractor(s)
+    res = ds.aggregate_metadata()
+    # aggregation done without whining
+    assert_status('ok', res)
+    res = ds.metadata(reporton='files')
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, path=op.join(ds.path, 'myfake.nidm.zip'))
+    # TODO test the actual metadata content, but not now, as it will will
+    # soon to another structure
+
+    # unique metadata values include nidm results
+    res = ds.metadata(reporton='datasets')
+    assert_result_count(res, 1)
+    res = res[0]
+    assert_in(
+        'nidmresults',
+        res['metadata']['datalad_unique_content_properties'])
+    assert_in(
+        'Contrasts',
+        res['metadata']['datalad_unique_content_properties']['nidmresults'])

--- a/datalad_neuroimaging/extractors/tests/test_nidmresults.py
+++ b/datalad_neuroimaging/extractors/tests/test_nidmresults.py
@@ -22,781 +22,1485 @@ from datalad.tests.utils import assert_result_count
 
 example_metadata = """\
 {
-   "records" : {
-      "SupraThresholdCluster" : [
-         {
-            "@id" : "niiri:supra_threshold_cluster_0001",
-            "clusterSizeInResels" : "6.31265696809113",
-            "qValueFDR" : "1.77948412240239e-18",
-            "rdfs:label" : "Supra-Threshold Cluster: 0001",
-            "clusterLabelId" : "1",
-            "@type" : "Entity",
-            "clusterSizeInVoxels" : "839",
-            "pValueUncorrected" : "3.55896824480477e-19",
-            "pValueFWER" : "0.0",
-            "wasDerivedFrom" : "niiri:excursion_set_map_id"
-         },
-         {
-            "pValueFWER" : "0.0",
-            "pValueUncorrected" : "5.34280282632073e-17",
-            "clusterSizeInVoxels" : "695",
-            "wasDerivedFrom" : "niiri:excursion_set_map_id",
-            "qValueFDR" : "1.33570070658018e-16",
-            "rdfs:label" : "Supra-Threshold Cluster: 0002",
-            "clusterLabelId" : "2",
-            "@id" : "niiri:supra_threshold_cluster_0002",
-            "clusterSizeInResels" : "5.22919736927692",
-            "@type" : "Entity"
-         }
+  "@context": {
+    "FeasibleGeneralizedLeastSquaresEstimation": "http://purl.obolibrary.org/obo/STATO_0000374",
+    "termEditor": "http://purl.obolibrary.org/obo/IAO_0000117",
+    "targetIntensity": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000124",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "nlx": "http://uri.neuinfo.org/nif/nifstd/",
+    "OrganizationalTerm": "http://purl.obolibrary.org/obo/IAO_0000121",
+    "IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+    "ContinuousProbabilityDistribution": "http://purl.obolibrary.org/obo/STATO_0000067",
+    "CompoundSymmetryCovarianceStructure": "http://purl.obolibrary.org/obo/STATO_0000362",
+    "noiseRoughnessInVoxels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000145",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "PendingFinalVetting": "http://purl.obolibrary.org/obo/IAO_0000125",
+    "ZStatistic": "http://purl.obolibrary.org/obo/STATO_0000376",
+    "GeneralizedLeastSquaresEstimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+    "searchVolumeInVoxels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000121",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "scr": "http://scicrunch.org/resolver/",
+    "hasShortcutProperty": {
+      "@id": "http://purl.org/ontology/prv/core#shortcut_property",
+      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+    },
+    "title": "http://purl.org/dc/elements/1.1/title",
+    "clusterSizeInVertices": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000083",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "isUserDefined": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000106",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+    "ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+    "CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+    "UnstructuredCovarianceStructure": "http://purl.obolibrary.org/obo/STATO_0000405",
+    "FSLsGammaHRF": "http://purl.org/nidash/fsl#FSL_0000006",
+    "SPM": "http://scicrunch.org/resolver/SCR_007037",
+    "DisplayMaskMap": "http://purl.org/nidash/nidm#NIDM_0000020",
+    "ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+    "ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+    "minDistanceBetweenPeaks": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000109",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "smallestSignificantClusterSizeInVerticesFDR05": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000011",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "MNICoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000051",
+    "ContrastExplainedMeanSquareMap": "http://purl.org/nidash/nidm#NIDM_0000163",
+    "DiscreteProbabilityDistribution": "http://purl.obolibrary.org/obo/STATO_0000117",
+    "IcbmMni152NonLinear2009cAsymmetricCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000045",
+    "ErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000022",
+    "GaussianDistribution": "http://purl.org/nidash/nidm#NIDM_0000032",
+    "Positron emission tomography scanner": "http://uri.neuinfo.org/nif/nifstd/ixl_0050000",
+    "SPMsTemporalDerivative": "http://purl.org/nidash/spm#SPM_0000006",
+    "Imaging instrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "TalairachCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000078",
+    "records": {
+      "@id": "@graph",
+      "@container": "@type"
+    },
+    "Cluster": "http://purl.org/nidash/nidm#NIDM_0000006",
+    "PositronEmissionTomographyScanner": "http://uri.neuinfo.org/nif/nifstd/ixl_0050000",
+    "dimensionsInVoxels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000090",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "OrdinaryLeastSquaresEstimation": "http://purl.obolibrary.org/obo/STATO_0000370",
+    "numberOfDimensions": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000112",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "effectDegreesOfFreedom": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000091",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "NonParametricDistribution": "http://purl.org/nidash/nidm#NIDM_0000058",
+    "smallestSignificantClusterSizeInVoxelsFWE05": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000014",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+    "GaussianRunningLineDriftModel": "http://purl.org/nidash/fsl#FSL_0000002",
+    "alternativeTerm": "http://purl.obolibrary.org/obo/IAO_0000118",
+    "CustomCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000017",
+    "TStatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+    "NIDMResultsExporter": "http://purl.org/nidash/nidm#NIDM_0000165",
+    "hasDriftModel": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000088",
+      "@type": "http://purl.org/nidash/spm#SPM_0000002"
+    },
+    "Icbm452AirCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000038",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "coordinateVector": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000086",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "statisticType": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000123",
+      "@type": "http://purl.obolibrary.org/obo/STATO_0000176"
+    },
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "Statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+    "ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+    "IAORelease20150223": "http://purl.obolibrary.org/obo/iao/2015-02-23/iao.owl",
+    "FSLsGammaDifferenceHRF": "http://purl.org/nidash/fsl#FSL_0000001",
+    "RegularizedParameter": "http://purl.org/nidash/nidm#NIDM_0000074",
+    "IcbmMni152NonLinear2009aSymmetricCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000042",
+    "SineBasisSet": "http://purl.org/nidash/nidm#NIDM_0000151",
+    "HemodynamicResponseFunctionDerivative": "http://purl.org/nidash/nidm#NIDM_0000037",
+    "BFOCLIFSpecificationLabel": "http://purl.obolibrary.org/obo/BFO_0000180",
+    "exampleOfUsage": "http://purl.obolibrary.org/obo/IAO_0000112",
+    "GammaHRF": "http://purl.org/nidash/nidm#NIDM_0000031",
+    "creator": "http://purl.org/dc/elements/1.1/creator",
+    "DiffusionWeightedImagingProtocol": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_20090249",
+    "FourierBasisSet": "http://purl.org/nidash/nidm#NIDM_0000069",
+    "ArbitrarilyCorrelatedError": "http://purl.org/nidash/nidm#NIDM_0000003",
+    "voxelUnits": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000133",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "DiscreteCosineTransformbasisDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+    "noiseFWHMInVoxels": "http://purl.org/nidash/spm#SPM_0000009",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+    "LegendrePolynomialOrder": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000014",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "errorDegreesOfFreedom": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000093",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "searchVolumeInResels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000149",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "StudyGroupPopulation": "http://purl.obolibrary.org/obo/STATO_0000193",
+    "definitionSource": "http://purl.obolibrary.org/obo/IAO_0000119",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "description": {
+      "@id": "http://purl.org/dc/elements/1.1/description",
+      "@type": "http://purl.org/dc/dcmitype/Image"
+    },
+    "voxel6connected": "http://purl.org/nidash/nidm#NIDM_0000130",
+    "SubjectCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000077",
+    "userSpecifiedThresholdType": "http://purl.org/nidash/nidm#NIDM_0000125",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "NonParametricSymmetricDistribution": "http://purl.org/nidash/nidm#NIDM_0000059",
+    "hasMapHeader": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000103",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000053"
+    },
+    "randomFieldStationarity": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000120",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "expectedNumberOfVerticesPerCluster": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000142",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+    "GammaBasisSet": "http://purl.org/nidash/nidm#NIDM_0000030",
+    "BFOOWLSpecificationLabel": "http://purl.obolibrary.org/obo/BFO_0000179",
+    "IcbmMni152NonLinear2009aAsymmetricCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000041",
+    "version": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000127",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "RequiresDiscussion": "http://purl.obolibrary.org/obo/IAO_0000428",
+    "varianceMapWiseDependence": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000126",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000074"
+    },
+    "contrastName": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000085",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "editorPreferredTerm": "http://purl.obolibrary.org/obo/IAO_0000111",
+    "ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+    "SPMsDispersionDerivative": "http://purl.org/nidash/spm#SPM_0000003",
+    "ModelParameterEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+    "ToeplitzCovarianceStructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+    "GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+    "hasErrorDistribution": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000101",
+      "@type": "http://purl.obolibrary.org/obo/STATO_0000067"
+    },
+    "GammaDifferenceHRF": "http://purl.org/nidash/nidm#NIDM_0000029",
+    "withEstimationMethod": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000134",
+      "@type": "http://purl.obolibrary.org/obo/STATO_0000119"
+    },
+    "PixelConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000064",
+    "nidm": "http://purl.org/nidash/nidm#",
+    "clusterSizeInVoxels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000084",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "hasShortcut": {
+      "@id": "http://purl.org/ontology/prv/core#shortcut",
+      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+    },
+    "WeightedLeastSquaresEstimation": "http://purl.obolibrary.org/obo/STATO_0000371",
+    "dct": "http://purl.org/dc/terms/",
+    "ConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000012",
+    "StructuralMRIProtocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2251",
+    "niiri": "http://iri.nidash.org/",
+    "reselSizeInVoxels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000148",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "hasMRIProtocol": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000172",
+      "@type": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_20090249"
+    },
+    "definition": "http://purl.obolibrary.org/obo/IAO_0000115",
+    "DriftModel": "http://purl.org/nidash/nidm#NIDM_0000087",
+    "Magnetoencephalography machine": "http://uri.neuinfo.org/nif/nifstd/ixl_0050002",
+    "IcbmMni152NonLinear2009cSymmetricCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000046",
+    "voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+    "voxel26connected": "http://purl.org/nidash/nidm#NIDM_0000129",
+    "hasMaximumIntensityProjection": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000138",
+      "@type": "http://purl.org/dc/dcmitype/Image"
+    },
+    "NormalDistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+    "hasConnectivityCriterion": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000099",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000064"
+    },
+    "ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+    "ChiSquaredStatistic": "http://purl.obolibrary.org/obo/STATO_0000030",
+    "Mni305CoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000055",
+    "importedFrom": "http://purl.obolibrary.org/obo/IAO_0000412",
+    "BinomialDistribution": "http://purl.org/nidash/nidm#NIDM_0000005",
+    "ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+    "@version": 1.1,
+    "CustomBasisSet": "http://purl.org/nidash/nidm#NIDM_0000067",
+    "ReadyForRelease": "http://purl.obolibrary.org/obo/IAO_0000122",
+    "hasAlternativeHypothesis": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000097",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000060"
+    },
+    "pValueFWER": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000115",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+    "pixel4connected": "http://purl.org/nidash/nidm#NIDM_0000117",
+    "AFNIsGammaHRF": "http://purl.org/nidash/afni#GammaHRF",
+    "ConjunctionInference": "http://purl.org/nidash/nidm#NIDM_0000011",
+    "IcbmMni152LinearCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000040",
+    "FSL": "http://scicrunch.org/resolver/SCR_002823",
+    "MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+    "CovarianceStructure": "http://purl.obolibrary.org/obo/STATO_0000346",
+    "contributor": "http://purl.org/dc/elements/1.1/contributor",
+    "heightCriticalThresholdFDR05": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000146",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "AFNIsLegendrePolinomialDriftModel": "http://purl.org/nidash/afni#LegendrePolynomialDriftModel",
+    "numberOfSubjects": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000171",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "IcbmMni152NonLinear2009bAsymmetricCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000043",
+    "hasClusterLabelsMap": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000098",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000008"
+    },
+    "expectedNumberOfClusters": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000141",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "Structural MRI protocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2251",
+    "ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+    "VoxelConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000080",
+    "numberOfSupraThresholdClusters": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000111",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "ToBeReplacedWithExternalOntologyTerm": "http://purl.obolibrary.org/obo/IAO_0000423",
+    "FSLsTemporalDerivative": "http://purl.org/nidash/fsl#FSL_0000003",
+    "pValue": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000114",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "FWERAdjustedPValue": "http://purl.obolibrary.org/obo/OBI_0001265",
+    "ExchangeableError": "http://purl.org/nidash/nidm#NIDM_0000024",
+    "MapHeader": "http://purl.org/nidash/nidm#NIDM_0000053",
+    "MetadataIncomplete": "http://purl.obolibrary.org/obo/IAO_0000123",
+    "MetadataComplete": "http://purl.obolibrary.org/obo/IAO_0000120",
+    "qValueFDR": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000119",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "IndependentError": "http://purl.org/nidash/nidm#NIDM_0000048",
+    "hasHRFBasis": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000102",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000028"
+    },
+    "ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+    "ImagingInstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+    "inCoordinateSpace": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000104",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000016"
+    },
+    "Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+    "DataScaling": "http://purl.org/nidash/nidm#NIDM_0000018",
+    "BinaryMap": "http://purl.org/nidash/nidm#NIDM_0000004",
+    "ConvolutionBasisSet": "http://purl.org/nidash/nidm#NIDM_0000036",
+    "pValueUncorrected": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000116",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "obo": "http://purl.obolibrary.org/obo/",
+    "OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+    "afni": "http://purl.org/nidash/afni#",
+    "GaussianHRF": "http://purl.org/nidash/nidm#NIDM_0000110",
+    "QValue": "http://purl.obolibrary.org/obo/OBI_0001442",
+    "clusterLabelId": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000082",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+    "Electroencephalography machine": "http://uri.neuinfo.org/nif/nifstd/ixl_0050003",
+    "PropertyReification": "http://purl.org/ontology/prv/core#PropertyReification",
+    "voxelSize": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000131",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "IcbmMni152NonLinear2009bSymmetricCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000044",
+    "expectedNumberOfVoxelsPerCluster": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000143",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "LinearSplineBasisSet": "http://purl.org/nidash/nidm#NIDM_0000150",
+    "Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+    "MagnetoencephalographyMachine": "http://uri.neuinfo.org/nif/nifstd/ixl_0050002",
+    "grandMeanScaling": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000096",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "Single-photon emission computed tomography scanner": "http://uri.neuinfo.org/nif/nifstd/ixl_0050001",
+    "clusterSizeInResels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000156",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+    "softwareVersion": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000122",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "Uncurated": "http://purl.obolibrary.org/obo/IAO_0000124",
+    "inWorldCoordinateSystem": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000105",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000017"
+    },
+    "regressorNames": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000021",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166",
+    "Diffusion-weighted imaging protocol": "http://uri.neuinfo.org/nif/nifstd/nlx_inv_20090249",
+    "IterativelyReweightedLeastSquaresEstimation": "http://purl.obolibrary.org/obo/STATO_0000373",
+    "noiseFWHMInVertices": "http://purl.org/nidash/spm#SPM_0000008",
+    "elucidation": "http://purl.obolibrary.org/obo/IAO_0000600",
+    "maskedMedian": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000107",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "errorVarianceHomogeneous": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000094",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "objectModel": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000113",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000057"
+    },
+    "searchVolumeInVertices": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000137",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "noiseFWHMInUnits": "http://purl.org/nidash/spm#SPM_0000007",
+    "IcbmMni152NonLinear6thGenerationCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000047",
+    "hasErrorDependence": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000100",
+      "@type": "http://purl.obolibrary.org/obo/STATO_0000405"
+    },
+    "searchVolumeReselsGeometry": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000010",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "hasCurationStatus": "http://purl.obolibrary.org/obo/IAO_0000114",
+    "smallestSignificantClusterSizeInVoxelsFDR05": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000013",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "Magnetic resonance imaging scanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+    "spm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "TwoTailedTest": "http://purl.org/nidash/nidm#NIDM_0000079",
+    "SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+    "Functional MRI protocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+    "NIDMObjectModel": "http://purl.org/nidash/nidm#NIDM_0000057",
+    "Icbm452Warp5CoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000039",
+    "ProbabilityDistribution": "http://purl.obolibrary.org/obo/STATO_0000225",
+    "coordinateVectorInVoxels": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000139",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ElectroencephalographyMachine": "http://uri.neuinfo.org/nif/nifstd/ixl_0050003",
+    "SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+    "StandardizedCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000075",
+    "Map": "http://purl.org/nidash/nidm#NIDM_0000052",
+    "pixel8connected": "http://purl.org/nidash/nidm#NIDM_0000118",
+    "PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+    "dependenceMapWiseDependence": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000089",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000074"
+    },
+    "driftCutoffPeriod": {
+      "@id": "http://purl.org/nidash/fsl#FSL_0000004",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "hasObjectProperty": {
+      "@id": "http://purl.org/ontology/prv/core#object_property",
+      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+    },
+    "DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+    "equivalentThreshold": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000161",
+      "@type": "http://purl.org/nidash/nidm#NIDM_0000162"
+    },
+    "editorNote": "http://purl.obolibrary.org/obo/IAO_0000116",
+    "FunctionalMRIProtocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+    "curatorNote": "http://purl.obolibrary.org/obo/IAO_0000232",
+    "ClusterCenterOfGravity": "http://purl.org/nidash/nidm#NIDM_0000140",
+    "ExampleToBeEventuallyRemoved": "http://purl.obolibrary.org/obo/IAO_0000002",
+    "nidmfsl": "http://purl.org/nidash/nidm#NIDM_0000167",
+    "groupName": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000170",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ErrorParameterMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000071",
+    "SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+    "SPMsDriftCutoffPeriod": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000001",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "Colin27CoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000009",
+    "partialConjunctionDegree": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000015",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "featVersion": {
+      "@id": "http://purl.org/nidash/fsl#FSL_0000005",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "IsAbout": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "ContrastWeightMatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+    "HasValue": "http://purl.obolibrary.org/obo/STATO_0000129",
+    "MRIProtocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2177",
+    "heightCriticalThresholdFWE05": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000147",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "hasReificationClass": {
+      "@id": "http://purl.org/ontology/prv/core#reification_class",
+      "@type": "http://www.w3.org/2002/07/owl#Class"
+    },
+    "equivalentZStatistic": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000092",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "smallestSignificantClusterSizeInVerticesFWE05": {
+      "@id": "http://purl.org/nidash/spm#SPM_0000012",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "MRI protocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2177",
+    "date": "http://purl.org/dc/elements/1.1/date",
+    "maxNumberOfPeaksPerCluster": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000108",
+      "@type": "http://www.w3.org/2001/XMLSchema#int"
+    },
+    "PoissonDistribution": "http://purl.org/nidash/nidm#NIDM_0000065",
+    "WorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000081",
+    "Ixi549CoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000050",
+    "Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+    "FStatistic": "http://purl.obolibrary.org/obo/STATO_0000282",
+    "hasSubjectProperty": {
+      "@id": "http://purl.org/ontology/prv/core#subject_property",
+      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+    },
+    "NeuroimagingAnalysisSoftware": "http://purl.org/nidash/nidm#NIDM_0000164",
+    "AnatomicalMRIProtocol": "http://uri.neuinfo.org/nif/nifstd/ixl_0050004",
+    "fsl": "http://purl.org/nidash/fsl#",
+    "PartialConjunctionInference": "http://purl.org/nidash/spm#SPM_0000005",
+    "FiniteImpulseResponseBasisSet": "http://purl.org/nidash/nidm#NIDM_0000028",
+    "ContrastVarianceMap": "http://purl.org/nidash/nidm#NIDM_0000135",
+    "SinglePhotonEmissionComputedTomographyScanner": "http://uri.neuinfo.org/nif/nifstd/ixl_0050001",
+    "MagneticResonanceImagingScanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+    "HemodynamicResponseFunction": "http://purl.org/nidash/nidm#NIDM_0000035",
+    "prov": "http://www.w3.org/ns/prov#",
+    "Threshold": "http://purl.org/nidash/nidm#NIDM_0000162",
+    "searchVolumeInUnits": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000136",
+      "@type": "http://www.w3.org/2001/XMLSchema#float"
+    },
+    "StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+    "voxelToWorldMapping": {
+      "@id": "http://purl.org/nidash/nidm#NIDM_0000132",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    }
+  },
+  "@id": "file:///Users/camaumet/Softs/nidm-specs/nidm/nidm-results/spm/spm_results.ttl",
+  "records": {
+    "PeakDefinitionCriteria": {
+      "maxNumberOfPeaksPerCluster": "3",
+      "minDistanceBetweenPeaks": "8.0",
+      "@id": "niiri:peak_definition_criteria_id",
+      "rdfs:label": "Peak Definition Criteria"
+    },
+    "DesignMatrix": {
+      "rdfs:label": "Design Matrix",
+      "dc:description": {
+        "@id": "niiri:design_matrix_png_id"
+      },
+      "nfo:fileName": "DesignMatrix.csv",
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "DesignMatrix.csv"
+      },
+      "@id": "niiri:design_matrix_id",
+      "dct:format": "text/csv"
+    },
+    "HeightThreshold": [
+      {
+        "nidm:NIDM_0000161": [
+          {
+            "@id": "niiri:height_threshold_id_2"
+          },
+          {
+            "@id": "niiri:height_threshold_id_3"
+          }
+        ],
+        "@id": "niiri:height_threshold_id",
+        "@type": "FWERAdjustedPValue",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "0.05"
+        },
+        "rdfs:label": "Height Threshold: p<0.05 (FWE)"
+      },
+      {
+        "rdfs:label": "Height Threshold: p<5.23529984739211",
+        "@id": "niiri:height_threshold_id_2",
+        "@type": "Statistic",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "5.23529984739"
+        }
+      }
+    ],
+    "StudyGroupPopulation": [
+      {
+        "rdfs:label": "Group: Patient",
+        "@id": "niiri:group2_id",
+        "nidm:NIDM_0000170": "Patient",
+        "numberOfSubjects": "21"
+      },
+      {
+        "rdfs:label": "Group: Control",
+        "@id": "niiri:group_id",
+        "nidm:NIDM_0000170": "Control",
+        "numberOfSubjects": "23"
+      }
+    ],
+    "ParameterEstimateMap": [
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:beta_map_id_2_der"
+        },
+        "rdfs:label": "Beta Map 2",
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:model_pe_id"
+        },
+        "nfo:fileName": "ParameterEstimate_002.nii.gz",
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "ParameterEstimate_002.nii"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:beta_map_id_2",
+        "dct:format": "image/nifti"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:beta_map_id_1_der"
+        },
+        "rdfs:label": "Beta Map 1",
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:model_pe_id"
+        },
+        "nfo:fileName": "ParameterEstimate_001.nii.gz",
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "ParameterEstimate_001.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:beta_map_id_1",
+        "dct:format": "image/nifti"
+      },
+      {
+        "nfo:fileName": "beta_0002.img",
+        "nidm:NIDM_0000103": {
+          "@id": "niiri:original_pe_map_header_2_id"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:beta_map_id_2_der",
+        "dct:format": "image/nifti"
+      },
+      {
+        "nfo:fileName": "beta_0001.img",
+        "nidm:NIDM_0000103": {
+          "@id": "niiri:original_pe_map_header_id"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:beta_map_id_1_der",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "GrandMeanMap": {
+      "rdfs:label": "Grand Mean Map",
+      "prov:wasGeneratedBy": {
+        "@id": "niiri:model_pe_id"
+      },
+      "maskedMedian": "115.0",
+      "nfo:fileName": "GrandMean.nii.gz",
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_1"
+      },
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "GrandMean.nii.gz"
+      },
+      "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+      "@id": "niiri:grand_mean_map_id",
+      "dct:format": "image/nifti"
+    },
+    "prov:SoftwareAgent": {
+      "rdfs:label": "SPM",
+      "nidm:NIDM_0000122": "12b.5853",
+      "@id": "niiri:software_id",
+      "@type": "SPM"
+    },
+    "PValueUncorrected": [
+      {
+        "rdfs:label": "Extent Threshold",
+        "@id": "niiri:extent_threshold_id_3",
+        "@type": "ExtentThreshold",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "1.0"
+        }
+      },
+      {
+        "rdfs:label": "Height Threshold: p<7.62276079258051e-07 (uncorrected)",
+        "@id": "niiri:height_threshold_id_3",
+        "@type": "HeightThreshold",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "7.62276079258e-07"
+        }
+      }
+    ],
+    "SupraThresholdCluster": [
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:excursion_set_map_id"
+        },
+        "pValueFWER": "1.392379545e-10",
+        "clusterSizeInVoxels": "38",
+        "pValueUncorrected": "1.56592642027e-09",
+        "rdfs:label": "Supra-Threshold Cluster 0003",
+        "qValueFDR": "4.17580378739e-09",
+        "clusterSizeInResels": "1.65772626435",
+        "clusterLabelId": "3",
+        "@id": "niiri:supra_threshold_cluster_0003"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:excursion_set_map_id"
+        },
+        "pValueFWER": "0.0",
+        "clusterSizeInVoxels": "445",
+        "pValueUncorrected": "3.91543427862e-46",
+        "rdfs:label": "Supra-Threshold Cluster 0002",
+        "qValueFDR": "1.56617371145e-45",
+        "clusterSizeInResels": "19.412847043",
+        "clusterLabelId": "2",
+        "@id": "niiri:supra_threshold_cluster_0002"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:excursion_set_map_id"
+        },
+        "pValueFWER": "0.0",
+        "clusterSizeInVoxels": "530",
+        "pValueUncorrected": "9.56276736481e-52",
+        "rdfs:label": "Supra-Threshold Cluster 0001",
+        "qValueFDR": "7.65021389185e-51",
+        "clusterSizeInResels": "23.1209189501",
+        "clusterLabelId": "1",
+        "@id": "niiri:supra_threshold_cluster_0001"
+      }
+    ],
+    "MaskMap": [
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "nfo:fileName": "MaskMap_1_der.nii",
+        "@id": "niiri:mask_id_1_der",
+        "dct:format": "image/nifti"
+      },
+      {
+        "nfo:fileName": "mask.img",
+        "nidm:NIDM_0000103": {
+          "@id": "niiri:original_mask_map_header_id"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:mask_id_2_der",
+        "dct:format": "image/nifti"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:mask_id_1_der"
+        },
+        "rdfs:label": "Mask Map 1",
+        "nfo:fileName": "Mask_1.nii.gz",
+        "nidm:NIDM_0000106": true,
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "Mask_1.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:mask_id_1",
+        "dct:format": "image/nifti"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:mask_id_2_der"
+        },
+        "rdfs:label": "Mask Map 2",
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:model_pe_id"
+        },
+        "nfo:fileName": "Mask.nii.gz",
+        "nidm:NIDM_0000106": false,
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "Mask.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:mask_id_2",
+        "dct:format": "image/nifti"
+      },
+      {
+        "rdfs:label": "Mask Map",
+        "nfo:fileName": "Mask_3.nii.gz",
+        "nidm:NIDM_0000106": true,
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_2"
+        },
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "Mask_3.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:mask_id_3",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "ExtentThreshold": [
+      {
+        "rdfs:label": "Extent Threshold: k>=0",
+        "clusterSizeInVoxels": "0",
+        "@id": "niiri:extent_threshold_id",
+        "clusterSizeInResels": "0.0",
+        "nidm:NIDM_0000161": [
+          {
+            "@id": "niiri:height_threshold_id_3"
+          },
+          {
+            "@id": "niiri:height_threshold_id_2"
+          }
+        ],
+        "@type": "Statistic"
+      },
+      {
+        "rdfs:label": "Extent Threshold",
+        "@id": "niiri:extent_threshold_id_2",
+        "@type": "FWERAdjustedPValue",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "1.0"
+        }
+      }
+    ],
+    "CoordinateSpace": [
+      {
+        "rdfs:label": "Coordinate space 2",
+        "nidm:NIDM_0000132": "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -50],[0, 0, 0, 1]]",
+        "nidm:NIDM_0000133": "[ \\"mm\\", \\"mm\\", \\"mm\\" ]",
+        "nidm:NIDM_0000105": {
+          "@id": "nidm:NIDM_0000051"
+        },
+        "nidm:NIDM_0000131": "[ 3, 3, 3 ]",
+        "nidm:NIDM_0000090": "[ 53, 63, 46 ]",
+        "numberOfDimensions": "3",
+        "@id": "niiri:coordinate_space_id_2"
+      },
+      {
+        "rdfs:label": "Coordinate space 1",
+        "nidm:NIDM_0000132": "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -50],[0, 0, 0, 1]]",
+        "nidm:NIDM_0000133": "[ \\"mm\\", \\"mm\\", \\"mm\\" ]",
+        "nidm:NIDM_0000105": {
+          "@id": "nidm:NIDM_0000051"
+        },
+        "nidm:NIDM_0000131": "[ 3, 3, 3 ]",
+        "nidm:NIDM_0000090": "[ 53, 63, 46 ]",
+        "numberOfDimensions": "3",
+        "@id": "niiri:coordinate_space_id_1"
+      }
+    ],
+    "prov:Generation": {
+      "prov:atTime": {
+        "@type": "xsd:dateTime",
+        "@value": "2014-05-19T10:30:00+01:00"
+      },
+      "@id": "_:fbfe9825b225641a29fc0e8ac5eb8d33cb1",
+      "prov:activity": {
+        "@id": "niiri:export_id"
+      }
+    },
+    "ExcursionSetMap": {
+      "rdfs:label": "Excursion Set Map",
+      "pValue": "8.95949980873e-14",
+      "prov:wasGeneratedBy": {
+        "@id": "niiri:inference_id"
+      },
+      "numberOfSupraThresholdClusters": "8",
+      "nidm:NIDM_0000098": {
+        "@id": "niiri:cluster_label_map_id"
+      },
+      "nfo:fileName": "ExcursionSet.nii.gz",
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_1"
+      },
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "ExcursionSet.nii.gz"
+      },
+      "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+      "nidm:NIDM_0000138": {
+        "@id": "niiri:maximum_intensity_projection_id"
+      },
+      "@id": "niiri:excursion_set_map_id",
+      "dct:format": "image/nifti"
+    },
+    "MapHeader": [
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...",
+        "nfo:fileName": "beta_0002.hdr",
+        "@id": "niiri:original_pe_map_header_2_id",
+        "@type": "prov:Entity",
+        "dct:format": "image/nifti"
+      },
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...",
+        "nfo:fileName": "mask.hdr",
+        "@id": "niiri:original_mask_map_header_id",
+        "@type": "prov:Entity",
+        "dct:format": "image/nifti"
+      },
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...",
+        "nfo:fileName": "con_0001.hdr",
+        "@id": "niiri:original_contrast_map_header_id",
+        "@type": "prov:Entity",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "Peak": [
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        },
+        "pValueFWER": "1.82057147136e-10",
+        "equivalentZStatistic": "7.80404869241",
+        "pValueUncorrected": "2.99760216649e-15",
+        "rdfs:label": "Peak 0003",
+        "qValueFDR": "9.95383070868e-08",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "9.82185649872"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0003"
+        },
+        "@id": "niiri:peak_0003"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        },
+        "pValueFWER": "0.0",
+        "equivalentZStatistic": "inf",
+        "pValueUncorrected": "4.4408920985e-16",
+        "rdfs:label": "Peak 0002",
+        "qValueFDR": "3.12855975726e-10",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "11.345749855"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0002"
+        },
+        "@id": "niiri:peak_0002"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0002"
+        },
+        "pValueFWER": "0.0",
+        "equivalentZStatistic": "inf",
+        "pValueUncorrected": "4.4408920985e-16",
+        "rdfs:label": "Peak 0005",
+        "qValueFDR": "6.3705194445e-11",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "12.3229017258"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0005"
+        },
+        "@id": "niiri:peak_0005"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0002"
+        },
+        "pValueFWER": "0.0",
+        "equivalentZStatistic": "inf",
+        "pValueUncorrected": "4.4408920985e-16",
+        "rdfs:label": "Peak 0004",
+        "qValueFDR": "6.3705194445e-11",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "13.7208814621"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0004"
+        },
+        "@id": "niiri:peak_0004"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0002"
+        },
+        "pValueFWER": "4.22372581355e-10",
+        "equivalentZStatistic": "7.70269435363",
+        "pValueUncorrected": "6.66133814775e-15",
+        "rdfs:label": "Peak 0006",
+        "qValueFDR": "1.58195372182e-07",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "9.62070846558"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0006"
+        },
+        "@id": "niiri:peak_0006"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        },
+        "pValueFWER": "0.0",
+        "equivalentZStatistic": "inf",
+        "pValueUncorrected": "4.4408920985e-16",
+        "rdfs:label": "Peak 0001",
+        "qValueFDR": "6.3705194445e-11",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "13.9346199036"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0001"
+        },
+        "@id": "niiri:peak_0001"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0003"
+        },
+        "pValueFWER": "4.05099727463e-06",
+        "equivalentZStatistic": "6.43494304364",
+        "pValueUncorrected": "6.17598194808e-11",
+        "rdfs:label": "Peak 0007",
+        "qValueFDR": "0.00046313051786",
+        "prov:value": {
+          "@type": "xsd:float",
+          "@value": "7.49709033966"
+        },
+        "prov:atLocation": {
+          "@id": "niiri:coordinate_0007"
+        },
+        "@id": "niiri:peak_0007"
+      }
+    ],
+    "ResidualMeanSquaresMap": {
+      "rdfs:label": "Residual Mean Squares Map",
+      "prov:wasGeneratedBy": {
+        "@id": "niiri:model_pe_id"
+      },
+      "nfo:fileName": "ResidualMeanSquares.nii.gz",
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_1"
+      },
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "ResidualMeanSquares.nii.gz"
+      },
+      "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+      "@id": "niiri:residual_mean_squares_map_id",
+      "dct:format": "image/nifti"
+    },
+    "ContrastEstimation": {
+      "rdfs:label": "Contrast estimation",
+      "prov:used": [
+        {
+          "@id": "niiri:residual_mean_squares_map_id"
+        },
+        {
+          "@id": "niiri:contrast_id"
+        },
+        {
+          "@id": "niiri:beta_map_id_2"
+        },
+        {
+          "@id": "niiri:mask_id_2"
+        },
+        {
+          "@id": "niiri:beta_map_id_1"
+        },
+        {
+          "@id": "niiri:design_matrix_id"
+        }
       ],
-      "FWERadjustedpvalue" : [
-         {
-            "@id" : "niiri:height_threshold_id",
-            "rdfs:label" : "Height Threshold: p<0.050000 (FWE)",
-            "prov:value" : {
-               "@value" : "0.05",
-               "@type" : "xsd:float"
-            },
-            "@type" : [
-               "HeightThreshold",
-               "Entity"
-            ],
-            "equivalentThreshold" : [
-               "niiri:height_threshold_id_3",
-               "niiri:height_threshold_id_2"
-            ]
-         },
-         {
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "1.0"
-            },
-            "@type" : [
-               "Entity",
-               "ExtentThreshold"
-            ],
-            "rdfs:label" : "Extent Threshold",
-            "@id" : "niiri:extent_threshold_id_2"
-         }
+      "@id": "niiri:contrast_estimation_id",
+      "prov:wasAssociatedWith": {
+        "@id": "niiri:software_id"
+      }
+    },
+    "ErrorModel": {
+      "nidm:NIDM_0000126": {
+        "@id": "nidm:NIDM_0000073"
+      },
+      "nidm:NIDM_0000094": true,
+      "nidm:NIDM_0000101": {
+        "@id": "obo:STATO_0000227"
+      },
+      "nidm:NIDM_0000100": {
+        "@id": "nidm:NIDM_0000048"
+      },
+      "@id": "niiri:error_model_id",
+      "nidm:NIDM_0000089": {
+        "@id": "nidm:NIDM_0000073"
+      }
+    },
+    "Data": {
+      "rdfs:label": "Data",
+      "prov:wasAttributedTo": [
+        {
+          "@id": "niiri:group2_id"
+        },
+        {
+          "@id": "niiri:mr_scanner_id"
+        },
+        {
+          "@id": "niiri:group_id"
+        }
       ],
-      "PValueUncorrected" : {
-         "@type" : [
-            "ExtentThreshold",
-            "Entity"
-         ],
-         "prov:value" : {
-            "@value" : "1.0",
-            "@type" : "xsd:float"
-         },
-         "rdfs:label" : "Extent Threshold",
-         "@id" : "niiri:extent_threshold_id_3"
+      "targetIntensity": "100.0",
+      "@id": "niiri:data_id",
+      "nidm:NIDM_0000096": true,
+      "nidm:NIDM_0000172": {
+        "@id": "nlx:birnlex_2250"
+      }
+    },
+    "ReselsPerVoxelMap": [
+      {
+        "nfo:fileName": "RPV.img",
+        "nidm:NIDM_0000103": {
+          "@id": "niiri:original_rpv_map_header_id"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:resels_per_voxel_map_id_der",
+        "dct:format": "image/nifti"
       },
-      "StatisticMap" : [
-         {
-            "@type" : "Entity",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "rdfs:label" : "T-Statistic Map: passive listening > rest",
-            "effectDegreesOfFreedom" : "1.0",
-            "@id" : "niiri:statistic_map_id",
-            "wasDerivedFrom" : "niiri:statistic_map_id_der",
-            "location" : "TStatistic.nii.gz",
-            "dct:format" : "image/nifti",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6",
-            "statisticType" : "http://purl.obolibrary.org/obo/STATO_0000176",
-            "wasGeneratedBy" : "niiri:contrast_estimation_id",
-            "nidm:NIDM_0000085" : "passive listening > rest",
-            "nfo:fileName" : "TStatistic.nii.gz",
-            "errorDegreesOfFreedom" : "84.0"
-         },
-         {
-            "dct:format" : "image/nifti",
-            "@type" : "Entity",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825",
-            "nfo:fileName" : "spmT_0001.nii",
-            "@id" : "niiri:statistic_map_id_der"
-         }
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:resels_per_voxel_map_id_der"
+        },
+        "rdfs:label": "Resels per Voxel Map",
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:model_pe_id"
+        },
+        "nfo:fileName": "ReselsPerVoxel.nii.gz",
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "ReselsPerVoxel.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:resels_per_voxel_map_id",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "NIDMResultsExport": {
+      "rdfs:label": "NIDM-Results export",
+      "@id": "niiri:export_id",
+      "prov:wasAssociatedWith": {
+        "@id": "niiri:exporter_id"
+      }
+    },
+    "Magnetic resonance imaging scanner": {
+      "rdfs:label": "MRI Scanner",
+      "@id": "niiri:mr_scanner_id",
+      "@type": "Imaging instrument"
+    },
+    "ModelParameterEstimation": {
+      "rdfs:label": "Model parameters estimation",
+      "prov:used": [
+        {
+          "@id": "niiri:mask_id_1"
+        },
+        {
+          "@id": "niiri:data_id"
+        },
+        {
+          "@id": "niiri:error_model_id"
+        },
+        {
+          "@id": "niiri:design_matrix_id"
+        }
       ],
-      "Location" : [
-         {
-            "@id" : "niiri:coordinate_0007",
-            "rdfs:label" : "Coordinate: 0007",
-            "@type" : [
-               "Coordinate",
-               "Entity"
-            ],
-            "nidm:NIDM_0000086" : "[ 36, -28, -13 ]"
-         },
-         {
-            "nidm:NIDM_0000086" : "[ -42, -31, 11 ]",
-            "@type" : [
-               "Coordinate",
-               "Entity"
-            ],
-            "rdfs:label" : "Coordinate: 0002",
-            "@id" : "niiri:coordinate_0002"
-         },
-         {
-            "@type" : [
-               "Coordinate",
-               "Entity"
-            ],
-            "nidm:NIDM_0000086" : "[ 57, -40, 5 ]",
-            "@id" : "niiri:coordinate_0006",
-            "rdfs:label" : "Coordinate: 0006"
-         }
+      "prov:wasAssociatedWith": {
+        "@id": "niiri:software_id"
+      },
+      "nidm:NIDM_0000134": {
+        "@id": "obo:STATO_0000370"
+      },
+      "@id": "niiri:model_pe_id"
+    },
+    "DisplayMaskMap": {
+      "rdfs:label": "Display Mask Map",
+      "nfo:fileName": "DisplayMask.nii.gz",
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_2"
+      },
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "DisplayMask.nii.gz"
+      },
+      "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+      "@id": "niiri:display_map_id",
+      "dct:format": "image/nifti"
+    },
+    "ContrastWeightMatrix": {
+      "rdfs:label": "Contrast: Listening > Rest",
+      "prov:value": "[ 1, 0, 0 ]",
+      "nidm:NIDM_0000123": {
+        "@id": "obo:STATO_0000176"
+      },
+      "nidm:NIDM_0000085": "listening > rest",
+      "@id": "niiri:contrast_id"
+    },
+    "http://purl.org/dc/dcmitype/Image": [
+      {
+        "nfo:fileName": "MaximumIntensityProjection.png",
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "MaximumIntensityProjection.png"
+        },
+        "@id": "niiri:maximum_intensity_projection_id",
+        "dct:format": "image/png"
+      },
+      {
+        "nfo:fileName": "DesignMatrix.png",
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "DesignMatrix.png"
+        },
+        "@id": "niiri:design_matrix_png_id",
+        "dct:format": "image/png"
+      }
+    ],
+    "NIDMResults": {
+      "rdfs:label": "NIDM-Results",
+      "prov:qualifiedGeneration": {
+        "@id": "_:fbfe9825b225641a29fc0e8ac5eb8d33cb1"
+      },
+      "@id": "niiri:spm_results_id",
+      "nidm:NIDM_0000127": "1.3.0"
+    },
+    "Coordinate": [
+      {
+        "nidm:NIDM_0000086": "[ 57, -40, 7 ]",
+        "rdfs:label": "Coordinate: 0006",
+        "@id": "niiri:coordinate_0006"
+      },
+      {
+        "nidm:NIDM_0000086": "[ 36, -31, -14 ]",
+        "rdfs:label": "Coordinate: 0007",
+        "@id": "niiri:coordinate_0007"
+      },
+      {
+        "nidm:NIDM_0000086": "[ 57, -22, 13 ]",
+        "rdfs:label": "Coordinate: 0004",
+        "@id": "niiri:coordinate_0004"
+      },
+      {
+        "nidm:NIDM_0000086": "[ 66, -13, -2 ]",
+        "rdfs:label": "Coordinate: 0005",
+        "@id": "niiri:coordinate_0005"
+      },
+      {
+        "nidm:NIDM_0000086": "[ -66, -13, 4 ]",
+        "rdfs:label": "Coordinate: 0002",
+        "@id": "niiri:coordinate_0002"
+      },
+      {
+        "nidm:NIDM_0000086": "[ -63, -7, -2 ]",
+        "rdfs:label": "Coordinate: 0003",
+        "@id": "niiri:coordinate_0003"
+      },
+      {
+        "nidm:NIDM_0000086": "[ -60, -28, 13 ]",
+        "rdfs:label": "Coordinate: 0001",
+        "@id": "niiri:coordinate_0001"
+      }
+    ],
+    "ContrastMap": [
+      {
+        "nfo:fileName": "con_0001.img",
+        "nidm:NIDM_0000103": {
+          "@id": "niiri:original_contrast_map_header_id"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:contrast_map_id_der",
+        "dct:format": "image/nifti"
+      },
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:contrast_map_id_der"
+        },
+        "rdfs:label": "Contrast Map: listening > rest",
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:contrast_estimation_id"
+        },
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "nfo:fileName": "Contrast.nii.gz",
+        "nidm:NIDM_0000085": "listening > rest",
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "Contrast.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:contrast_map_id",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "ClusterDefinitionCriteria": {
+      "nidm:NIDM_0000099": {
+        "@id": "nidm:NIDM_0000128"
+      },
+      "@id": "niiri:cluster_definition_criteria_id",
+      "rdfs:label": "Cluster Connectivity Criterion: 18"
+    },
+    "Inference": {
+      "rdfs:label": "Inference",
+      "prov:used": [
+        {
+          "@id": "niiri:mask_id_3"
+        },
+        {
+          "@id": "niiri:extent_threshold_id"
+        },
+        {
+          "@id": "niiri:cluster_definition_criteria_id"
+        },
+        {
+          "@id": "niiri:mask_id_2"
+        },
+        {
+          "@id": "niiri:peak_definition_criteria_id"
+        },
+        {
+          "@id": "niiri:height_threshold_id"
+        },
+        {
+          "@id": "niiri:statistic_map_id"
+        },
+        {
+          "@id": "niiri:resels_per_voxel_map_id"
+        }
       ],
-      "Magneticresonanceimagingscanner" : {
-         "rdfs:label" : "MRI Scanner",
-         "@id" : "niiri:mr_scanner_id",
-         "@type" : [
-            "Agent",
-            "Imaginginstrument"
-         ]
+      "prov:wasAssociatedWith": {
+        "@id": "niiri:software_id"
       },
-      "DesignMatrix" : {
-         "dct:format" : "text/csv",
-         "location" : "DesignMatrix.csv",
-         "nfo:fileName" : "DesignMatrix.csv",
-         "@type" : "Entity",
-         "hasDriftModel" : "niiri:drift_model_id",
-         "nidm:NIDM_0000021" : "[\\"Sn(1) active*bf(1)\\", \\"Sn(1) constant\\"]",
-         "Description" : "niiri:design_matrix_png_id",
-         "@id" : "niiri:design_matrix_id",
-         "hasHRFBasis" : "spm:SPM_0000004",
-         "rdfs:label" : "Design Matrix"
+      "nidm:NIDM_0000097": {
+        "@id": "nidm:NIDM_0000060"
       },
-      "Person" : {
-         "@type" : "Agent",
-         "rdfs:label" : "Person",
-         "@id" : "niiri:subject_id"
+      "@id": "niiri:inference_id"
+    },
+    "ClusterLabelsMap": {
+      "rdfs:label": "Cluster Labels Map",
+      "nfo:fileName": "ClusterLabels.nii.gz",
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_1"
       },
-      "ContrastStandardErrorMap" : {
-         "nfo:fileName" : "ContrastStandardError.nii.gz",
-         "location" : "ContrastStandardError.nii.gz",
-         "dct:format" : "image/nifti",
-         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2",
-         "wasGeneratedBy" : "niiri:contrast_estimation_id",
-         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-         "rdfs:label" : "Contrast Standard Error Map",
-         "@id" : "niiri:contrast_standard_error_map_id",
-         "@type" : "Entity"
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "ClusterLabels.nii.gz"
       },
-      "Activity" : [
-         {
-            "@type" : "ContrastEstimation",
-            "used" : [
-               "niiri:design_matrix_id",
-               "niiri:contrast_id",
-               "niiri:beta_map_id_1",
-               "niiri:residual_mean_squares_map_id",
-               "niiri:mask_id_1",
-               "niiri:beta_map_id_2"
-            ],
-            "rdfs:label" : "Contrast estimation",
-            "wasAssociatedWith" : "niiri:software_id",
-            "@id" : "niiri:contrast_estimation_id"
-         },
-         {
-            "@type" : "NIDMResultsExport",
-            "rdfs:label" : "NIDM-Results export",
-            "@id" : "niiri:export_id",
-            "wasAssociatedWith" : "niiri:exporter_id"
-         },
-         {
-            "@type" : "Inference",
-            "used" : [
-               "niiri:statistic_map_id",
-               "niiri:height_threshold_id",
-               "niiri:cluster_definition_criteria_id",
-               "niiri:resels_per_voxel_map_id",
-               "niiri:extent_threshold_id",
-               "niiri:mask_id_1",
-               "niiri:peak_definition_criteria_id"
-            ],
-            "hasAlternativeHypothesis" : "nidm:NIDM_0000060",
-            "wasAssociatedWith" : "niiri:software_id",
-            "@id" : "niiri:inference_id",
-            "rdfs:label" : "Inference"
-         }
-      ],
-      "ClusterLabelsMap" : {
-         "@type" : "Entity",
-         "@id" : "niiri:cluster_label_map_id",
-         "rdfs:label" : "Cluster Labels Map",
-         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a311a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3",
-         "dct:format" : "image/nifti",
-         "location" : "ClusterLabels.nii.gz",
-         "nfo:fileName" : "ClusterLabels.nii.gz"
+      "crypto:sha512": "13093aae03897e2518307d000eb298f4b1439814d8d3d77c622b717423f93506dd5de5669513ab65c6dd74a7d27ee9df08620f546ed00575517b40e5878c2c96",
+      "@id": "niiri:cluster_label_map_id",
+      "dct:format": "image/nifti"
+    },
+    "StatisticMap": [
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:statistic_map_id_der"
+        },
+        "rdfs:label": "T-Statistic Map: listening > rest",
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:contrast_estimation_id"
+        },
+        "errorDegreesOfFreedom": "72.9999999991",
+        "nidm:NIDM_0000104": {
+          "@id": "niiri:coordinate_space_id_1"
+        },
+        "nfo:fileName": "TStatistic.nii.gz",
+        "nidm:NIDM_0000123": {
+          "@id": "obo:STATO_0000176"
+        },
+        "nidm:NIDM_0000085": "listening > rest",
+        "prov:atLocation": {
+          "@type": "xsd:anyURI",
+          "@value": "TStatistic.nii.gz"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "effectDegreesOfFreedom": "1.0",
+        "@id": "niiri:statistic_map_id",
+        "dct:format": "image/nifti"
       },
-      "ErrorModel" : {
-         "hasErrorDistribution" : "http://purl.obolibrary.org/obo/STATO_0000227",
-         "@type" : "Entity",
-         "nidm:NIDM_0000094" : true,
-         "hasErrorDependence" : "http://purl.obolibrary.org/obo/STATO_0000357",
-         "@id" : "niiri:error_model_id",
-         "dependenceMapWiseDependence" : "nidm:NIDM_0000072",
-         "varianceMapWiseDependence" : "nidm:NIDM_0000073"
+      {
+        "nfo:fileName": "spmT_0001.img",
+        "nidm:NIDM_0000103": {
+          "@id": "niiri:statistic_original_map_header_id"
+        },
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+        "@id": "niiri:statistic_map_id_der",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "ContrastStandardErrorMap": {
+      "rdfs:label": "Contrast Standard Error Map",
+      "prov:wasGeneratedBy": {
+        "@id": "niiri:contrast_estimation_id"
       },
-      "Agent" : {
-         "@type" : [
-            "SoftwareAgent",
-            "SPM"
-         ],
-         "softwareVersion" : "12.12.1",
-         "rdfs:label" : "SPM",
-         "@id" : "niiri:software_id"
+      "nfo:fileName": "ContrastStandardError.nii.gz",
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_1"
       },
-      "Peak" : [
-         {
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0001",
-            "pValueUncorrected" : "4.44089209850063e-16",
-            "pValueFWER" : "7.69451169446711e-12",
-            "equivalentZStatistic" : "inf",
-            "atLocation" : "niiri:coordinate_0003",
-            "@type" : "Entity",
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "10.2856016159058"
-            },
-            "@id" : "niiri:peak_0003",
-            "qValueFDR" : "6.84121260274992e-10",
-            "rdfs:label" : "Peak: 0003"
-         },
-         {
-            "pValueFWER" : "6.9250605250204e-11",
-            "equivalentZStatistic" : "inf",
-            "pValueUncorrected" : "1.22124532708767e-15",
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0002",
-            "qValueFDR" : "6.52169693024352e-09",
-            "rdfs:label" : "Peak: 0006",
-            "@id" : "niiri:peak_0006",
-            "atLocation" : "niiri:coordinate_0006",
-            "@type" : "Entity",
-            "prov:value" : {
-               "@value" : "9.72103404998779",
-               "@type" : "xsd:float"
-            }
-         },
-         {
-            "prov:value" : {
-               "@value" : "5.27320194244385",
-               "@type" : "xsd:float"
-            },
-            "atLocation" : "niiri:coordinate_0009",
-            "@type" : "Entity",
-            "rdfs:label" : "Peak: 0009",
-            "qValueFDR" : "0.251554254717758",
-            "@id" : "niiri:peak_0009",
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0005",
-            "equivalentZStatistic" : "4.88682085490477",
-            "pValueFWER" : "0.0119099090973821",
-            "pValueUncorrected" : "5.12386299833523e-07"
-         }
-      ],
-      "ParameterEstimateMap" : [
-         {
-            "@id" : "niiri:beta_map_id_2_der",
-            "nfo:fileName" : "beta_0002.nii",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
-            "@type" : "Entity",
-            "dct:format" : "image/nifti"
-         },
-         {
-            "dct:format" : "image/nifti",
-            "@type" : "Entity",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
-            "nfo:fileName" : "beta_0001.nii",
-            "@id" : "niiri:beta_map_id_1_der"
-         }
-      ],
-      "ContrastMap" : {
-         "nfo:fileName" : "Contrast.nii.gz",
-         "location" : "Contrast.nii.gz",
-         "wasDerivedFrom" : "niiri:contrast_map_id_der",
-         "dct:format" : "image/nifti",
-         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2",
-         "nidm:NIDM_0000085" : "passive listening > rest",
-         "wasGeneratedBy" : "niiri:contrast_estimation_id",
-         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-         "rdfs:label" : "Contrast Map: passive listening > rest",
-         "@id" : "niiri:contrast_map_id",
-         "@type" : "Entity"
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "ContrastStandardError.nii.gz"
       },
-      "ModelParameterEstimation" : {
-         "wasAssociatedWith" : "niiri:software_id",
-         "@id" : "niiri:model_pe_id",
-         "withEstimationMethod" : "http://purl.obolibrary.org/obo/STATO_0000372",
-         "rdfs:label" : "Model parameters estimation",
-         "@type" : "Activity",
-         "used" : [
-            "niiri:data_id",
-            "niiri:error_model_id",
-            "niiri:design_matrix_id"
-         ]
+      "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+      "@id": "niiri:contrast_standard_error_map_id",
+      "dct:format": "image/nifti"
+    },
+    "prov:Entity": [
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...",
+        "nfo:fileName": "RPV.hdr",
+        "@id": "niiri:original_rpv_map_header_id",
+        "@type": "MapHeader",
+        "dct:format": "image/nifti"
       },
-      "HeightThreshold" : [
-         {
-            "@type" : [
-               "Entity",
-               "statistic"
-            ],
-            "prov:value" : {
-               "@value" : "4.85241745689539",
-               "@type" : "xsd:float"
-            },
-            "rdfs:label" : "Height Threshold",
-            "@id" : "niiri:height_threshold_id_2"
-         },
-         {
-            "@id" : "niiri:height_threshold_id_3",
-            "rdfs:label" : "Height Threshold",
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "2.7772578456986e-06"
-            },
-            "@type" : [
-               "Entity",
-               "PValueUncorrected"
-            ]
-         }
-      ],
-      "SoftwareAgent" : {
-         "@id" : "niiri:exporter_id",
-         "rdfs:label" : "spm_results_nidm",
-         "@type" : [
-            "spm_results_nidm",
-            "Agent"
-         ],
-         "softwareVersion" : "12b.5858"
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...",
+        "nfo:fileName": "beta_0001.hdr",
+        "@id": "niiri:original_pe_map_header_id",
+        "@type": "MapHeader",
+        "dct:format": "image/nifti"
       },
-      "Entity" : [
-         {
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "6.19558477401733"
-            },
-            "atLocation" : "niiri:coordinate_0008",
-            "@type" : "Peak",
-            "@id" : "niiri:peak_0008",
-            "qValueFDR" : "0.00949154522981781",
-            "rdfs:label" : "Peak: 0008",
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0004",
-            "pValueUncorrected" : "1.0325913235576e-08",
-            "equivalentZStatistic" : "5.60645028016544",
-            "pValueFWER" : "0.000382453907303626"
-         },
-         {
-            "nfo:fileName" : "GrandMean.nii.gz",
-            "maskedMedian" : "132.008995056152",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb",
-            "wasGeneratedBy" : "niiri:model_pe_id",
-            "location" : "GrandMean.nii.gz",
-            "dct:format" : "image/nifti",
-            "@id" : "niiri:grand_mean_map_id",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "rdfs:label" : "Grand Mean Map",
-            "@type" : "GrandMeanMap"
-         },
-         {
-            "@id" : "niiri:resels_per_voxel_map_id_der",
-            "nfo:fileName" : "RPV.nii",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d",
-            "@type" : "ReselsPerVoxelMap",
-            "dct:format" : "image/nifti"
-         },
-         {
-            "numberOfDimensions" : "3",
-            "nidm:NIDM_0000090" : "[ 53, 63, 52 ]",
-            "nidm:NIDM_0000132" : "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]",
-            "rdfs:label" : "Coordinate space 1",
-            "@id" : "niiri:coordinate_space_id_1",
-            "inWorldCoordinateSystem" : "nidm:NIDM_0000050",
-            "nidm:NIDM_0000131" : "[ 3, 3, 3 ]",
-            "nidm:NIDM_0000133" : "[ \\"mm\\", \\"mm\\", \\"mm\\" ]",
-            "@type" : "CoordinateSpace"
-         },
-         {
-            "nfo:fileName" : "mask.nii",
-            "@id" : "niiri:mask_id_1_der",
-            "dct:format" : "image/nifti",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11",
-            "@type" : "MaskMap"
-         },
-         {
-            "rdfs:label" : "Cluster Connectivity Criterion: 18",
-            "@id" : "niiri:cluster_definition_criteria_id",
-            "@type" : "ClusterDefinitionCriteria",
-            "hasConnectivityCriterion" : "nidm:NIDM_0000128"
-         },
-         {
-            "@type" : "ReselsPerVoxelMap",
-            "@id" : "niiri:resels_per_voxel_map_id",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "rdfs:label" : "Resels per Voxel Map",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a",
-            "wasGeneratedBy" : "niiri:model_pe_id",
-            "location" : "ReselsPerVoxel.nii.gz",
-            "wasDerivedFrom" : "niiri:resels_per_voxel_map_id_der",
-            "dct:format" : "image/nifti",
-            "nfo:fileName" : "ReselsPerVoxel.nii.gz"
-         },
-         {
-            "nidm:NIDM_0000085" : "passive listening > rest",
-            "@type" : "contrastweightmatrix",
-            "prov:value" : "[1, 0]",
-            "statisticType" : "http://purl.obolibrary.org/obo/STATO_0000176",
-            "@id" : "niiri:contrast_id",
-            "rdfs:label" : "Contrast: passive listening > rest"
-         },
-         {
-            "nfo:fileName" : "con_0001.nii",
-            "@id" : "niiri:contrast_map_id_der",
-            "dct:format" : "image/nifti",
-            "@type" : "ContrastMap",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22"
-         },
-         {
-            "wasDerivedFrom" : "niiri:excursion_set_map_id",
-            "clusterSizeInVoxels" : "29",
-            "pValueUncorrected" : "0.0110257032104773",
-            "pValueFWER" : "0.000565384750377596",
-            "@type" : "SupraThresholdCluster",
-            "clusterSizeInResels" : "0.218196724761195",
-            "@id" : "niiri:supra_threshold_cluster_0004",
-            "rdfs:label" : "Supra-Threshold Cluster: 0004",
-            "qValueFDR" : "0.0137821290130967",
-            "clusterLabelId" : "4"
-         },
-         {
-            "qValueFDR" : "0.00257605396646668",
-            "rdfs:label" : "Peak: 0007",
-            "@id" : "niiri:peak_0007",
-            "@type" : "Peak",
-            "atLocation" : "niiri:coordinate_0007",
-            "prov:value" : {
-               "@value" : "6.55745935440063",
-               "@type" : "xsd:float"
-            },
-            "equivalentZStatistic" : "5.87574033699266",
-            "pValueFWER" : "9.17574302586877e-05",
-            "pValueUncorrected" : "2.10478867668229e-09",
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0003"
-         },
-         {
-            "location" : "DesignMatrix.png",
-            "dct:format" : "image/png",
-            "@type" : "http://purl.org/dc/dcmitype/Image",
-            "nfo:fileName" : "DesignMatrix.png",
-            "@id" : "niiri:design_matrix_png_id"
-         },
-         {
-            "rdfs:label" : "Coordinate: 0008",
-            "@id" : "niiri:coordinate_0008",
-            "nidm:NIDM_0000086" : "[ -33, -31, -16 ]",
-            "@type" : [
-               "Location",
-               "Coordinate"
-            ]
-         },
-         {
-            "nfo:fileName" : "ExcursionSet.nii.gz",
-            "hasMaximumIntensityProjection" : "niiri:maximum_intensity_projection_id",
-            "numberOfSupraThresholdClusters" : "5",
-            "hasClusterLabelsMap" : "niiri:cluster_label_map_id",
-            "dct:format" : "image/nifti",
-            "location" : "ExcursionSet.nii.gz",
-            "wasGeneratedBy" : "niiri:inference_id",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652",
-            "rdfs:label" : "Excursion Set Map",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "@id" : "niiri:excursion_set_map_id",
-            "@type" : "ExcursionSetMap",
-            "pValue" : "2.83510681598e-09"
-         },
-         {
-            "@type" : "ResidualMeanSquaresMap",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd",
-            "dct:format" : "image/nifti",
-            "@id" : "niiri:residual_mean_squares_map_id_der",
-            "nfo:fileName" : "ResMS.nii"
-         },
-         {
-            "@type" : [
-               "NIDMResults",
-               "Bundle"
-            ],
-            "nidm:NIDM_0000127" : "1.3.0",
-            "@id" : "niiri:spm_results_id",
-            "qualifiedGeneration" : "_:f1b4bd76338a04597b3f698e59f695e53b1",
-            "rdfs:label" : "NIDM-Results"
-         },
-         {
-            "pValueUncorrected" : "4.44089209850063e-16",
-            "pValueFWER" : "0.0",
-            "equivalentZStatistic" : "inf",
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0002",
-            "@id" : "niiri:peak_0005",
-            "qValueFDR" : "1.19156591713838e-11",
-            "rdfs:label" : "Peak: 0005",
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "12.4728717803955"
-            },
-            "@type" : "Peak",
-            "atLocation" : "niiri:coordinate_0005"
-         },
-         {
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0002",
-            "pValueUncorrected" : "4.44089209850063e-16",
-            "equivalentZStatistic" : "inf",
-            "pValueFWER" : "0.0",
-            "atLocation" : "niiri:coordinate_0004",
-            "@type" : "Peak",
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "13.5425577163696"
-            },
-            "@id" : "niiri:peak_0004",
-            "rdfs:label" : "Peak: 0004",
-            "qValueFDR" : "1.19156591713838e-11"
-         },
-         {
-            "nfo:fileName" : "ResidualMeanSquares.nii.gz",
-            "wasDerivedFrom" : "niiri:residual_mean_squares_map_id_der",
-            "location" : "ResidualMeanSquares.nii.gz",
-            "dct:format" : "image/nifti",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b",
-            "wasGeneratedBy" : "niiri:model_pe_id",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "rdfs:label" : "Residual Mean Squares Map",
-            "@id" : "niiri:residual_mean_squares_map_id",
-            "@type" : "ResidualMeanSquaresMap"
-         },
-         {
-            "@type" : "DiscreteCosineTransformbasisDriftModel",
-            "rdfs:label" : "SPM's DCT Drift Model",
-            "spm:SPM_0000001" : {
-               "@type" : "xsd:float",
-               "@value" : "128.0"
-            },
-            "@id" : "niiri:drift_model_id"
-         },
-         {
-            "equivalentZStatistic" : "inf",
-            "pValueFWER" : "0.0",
-            "pValueUncorrected" : "4.44089209850063e-16",
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0001",
-            "qValueFDR" : "1.19156591713838e-11",
-            "rdfs:label" : "Peak: 0001",
-            "@id" : "niiri:peak_0001",
-            "prov:value" : {
-               "@value" : "17.5207633972168",
-               "@type" : "xsd:float"
-            },
-            "atLocation" : "niiri:coordinate_0001",
-            "@type" : "Peak"
-         },
-         {
-            "dct:format" : "image/png",
-            "location" : "MaximumIntensityProjection.png",
-            "@type" : "http://purl.org/dc/dcmitype/Image",
-            "nfo:fileName" : "MaximumIntensityProjection.png",
-            "@id" : "niiri:maximum_intensity_projection_id"
-         },
-         {
-            "pValueUncorrected" : "0.0818393184514307",
-            "clusterSizeInVoxels" : "12",
-            "pValueFWER" : "0.00418900977248904",
-            "wasDerivedFrom" : "niiri:excursion_set_map_id",
-            "@id" : "niiri:supra_threshold_cluster_0005",
-            "clusterSizeInResels" : "0.0902882999011843",
-            "clusterLabelId" : "5",
-            "rdfs:label" : "Supra-Threshold Cluster: 0005",
-            "qValueFDR" : "0.0818393184514307",
-            "@type" : "SupraThresholdCluster"
-         },
-         {
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
-            "wasGeneratedBy" : "niiri:model_pe_id",
-            "wasDerivedFrom" : "niiri:beta_map_id_2_der",
-            "location" : "ParameterEstimate_0002.nii.gz",
-            "dct:format" : "image/nifti",
-            "nfo:fileName" : "ParameterEstimate_0002.nii.gz",
-            "@type" : "ParameterEstimateMap",
-            "@id" : "niiri:beta_map_id_2",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "rdfs:label" : "Parameter Estimate Map 2"
-         },
-         {
-            "@id" : "niiri:peak_definition_criteria_id",
-            "rdfs:label" : "Peak Definition Criteria",
-            "minDistanceBetweenPeaks" : "8.0",
-            "maxNumberOfPeaksPerCluster" : "3",
-            "@type" : "PeakDefinitionCriteria"
-         },
-         {
-            "@type" : "ParameterEstimateMap",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "rdfs:label" : "Parameter Estimate Map 1",
-            "@id" : "niiri:beta_map_id_1",
-            "location" : "ParameterEstimate_0001.nii.gz",
-            "wasDerivedFrom" : "niiri:beta_map_id_1_der",
-            "dct:format" : "image/nifti",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
-            "wasGeneratedBy" : "niiri:model_pe_id",
-            "nfo:fileName" : "ParameterEstimate_0001.nii.gz"
-         },
-         {
-            "smallestSignificantClusterSizeInVoxelsFWE05" : "12",
-            "expectedNumberOfVoxelsPerCluster" : "4.02834655908613",
-            "nidm:NIDM_0000157" : "[ 16.2383695773208, 16.3091687172086, 13.5499997663244 ]",
-            "@id" : "niiri:search_space_mask_id",
-            "dct:format" : "image/nifti",
-            "reselSizeInVoxels" : "132.907586178202",
-            "searchVolumeInVoxels" : "69306",
-            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
-            "smallestSignificantClusterSizeInVoxelsFDR05" : "29",
-            "heightCriticalThresholdFWE05" : "4.85241745689539",
-            "@type" : "SearchSpaceMaskMap",
-            "rdfs:label" : "Search Space Mask Map",
-            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-            "searchVolumeInResels" : "467.07642343881",
-            "nidm:NIDM_0000120" : true,
-            "location" : "SearchSpaceMask.nii.gz",
-            "nidm:NIDM_0000159" : "[ 5.41278985910694, 5.43638957240286, 4.51666658877481 ]",
-            "wasGeneratedBy" : "niiri:inference_id",
-            "expectedNumberOfClusters" : "0.0512932943875478",
-            "spm:SPM_0000010" : "[7, 42.96312274763, 269.40914815306, 467.07642343881]",
-            "nfo:fileName" : "SearchSpaceMask.nii.gz",
-            "heightCriticalThresholdFDR05" : "5.7639536857605",
-            "searchVolumeInUnits" : "1871262.0"
-         },
-         {
-            "@id" : "niiri:supra_threshold_cluster_0003",
-            "clusterSizeInResels" : "0.278388924695318",
-            "rdfs:label" : "Supra-Threshold Cluster: 0003",
-            "qValueFDR" : "0.00829922079256674",
-            "clusterLabelId" : "3",
-            "@type" : "SupraThresholdCluster",
-            "pValueUncorrected" : "0.00497953247554004",
-            "clusterSizeInVoxels" : "37",
-            "pValueFWER" : "0.000255384009130943",
-            "wasDerivedFrom" : "niiri:excursion_set_map_id"
-         },
-         {
-            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0001",
-            "pValueUncorrected" : "4.44089209850063e-16",
-            "pValueFWER" : "0.0",
-            "equivalentZStatistic" : "inf",
-            "@type" : "Peak",
-            "atLocation" : "niiri:coordinate_0002",
-            "prov:value" : {
-               "@type" : "xsd:float",
-               "@value" : "13.0321407318"
-            },
-            "@id" : "niiri:peak_0002",
-            "qValueFDR" : "1.19156591714e-11",
-            "rdfs:label" : "Peak: 0002"
-         }
-      ],
-      "ExtentThreshold" : {
-         "@type" : [
-            "statistic",
-            "Entity"
-         ],
-         "equivalentThreshold" : [
-            "niiri:extent_threshold_id_2",
-            "niiri:extent_threshold_id_3"
-         ],
-         "@id" : "niiri:extent_threshold_id",
-         "clusterSizeInResels" : "0.0",
-         "clusterSizeInVoxels" : "0",
-         "rdfs:label" : "Extent Threshold: k>=0"
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...",
+        "nfo:fileName": "spmT_0001.hdr",
+        "@id": "niiri:statistic_original_map_header_id",
+        "@type": "MapHeader",
+        "dct:format": "image/nifti"
+      }
+    ],
+    "SearchSpaceMaskMap": {
+      "nidm:NIDM_0000157": "[ 8.87643567497404, 8.89885340008753, 7.83541276878791 ]",
+      "heightCriticalThresholdFDR05": "6.22537899017",
+      "nidm:NIDM_0000159": "[ 2.95881189165801, 2.96628446669584, 2.61180425626264 ]",
+      "smallestSignificantClusterSizeInVoxelsFDR05": "3",
+      "nfo:fileName": "SearchSpaceMask.nii.gz",
+      "searchVolumeInResels": "2552.68032522",
+      "prov:atLocation": {
+        "@type": "xsd:anyURI",
+        "@value": "SearchSpaceMask.nii.gz"
       },
-      "MaskMap" : {
-         "@type" : "Entity",
-         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
-         "rdfs:label" : "Mask",
-         "@id" : "niiri:mask_id_1",
-         "wasDerivedFrom" : "niiri:mask_id_1_der",
-         "location" : "Mask.nii.gz",
-         "dct:format" : "image/nifti",
-         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
-         "wasGeneratedBy" : "niiri:model_pe_id",
-         "nidm:NIDM_0000106" : false,
-         "nfo:fileName" : "Mask.nii.gz"
+      "searchVolumeInVoxels": "65593",
+      "prov:wasGeneratedBy": {
+        "@id": "niiri:inference_id"
       },
-      "Generation" : {
-         "activity" : "niiri:export_id",
-         "atTime" : "2014-05-19T10:30:00+01:00",
-         "@id" : "_:f1b4bd76338a04597b3f698e59f695e53b1"
+      "expectedNumberOfClusters": "0.088917268796",
+      "crypto:sha512": "e43b6e01b0463fe7d40782137867a",
+      "rdfs:label": "Search Space Mask Map",
+      "heightCriticalThresholdFWE05": "5.23529984739",
+      "@id": "niiri:search_space_mask_id",
+      "smallestSignificantClusterSizeInVoxelsFWE05": "1",
+      "expectedNumberOfVoxelsPerCluster": "0.553331387916",
+      "reselSizeInVoxels": "22.922964314",
+      "http://purl.org/nidash/spm#SPM_0000010": "[3, 72.3216126440484, 850.716735116472, 2552.68032521656]",
+      "nidm:NIDM_0000120": false,
+      "nidm:NIDM_0000104": {
+        "@id": "niiri:coordinate_space_id_2"
       },
-      "Collection" : {
-         "hasMRIProtocol" : "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
-         "@id" : "niiri:data_id",
-         "targetIntensity" : "100.0",
-         "wasAttributedTo" : [
-            "niiri:subject_id",
-            "niiri:mr_scanner_id"
-         ],
-         "rdfs:label" : "Data",
-         "nidm:NIDM_0000096" : true,
-         "@type" : [
-            "Data",
-            "Entity"
-         ]
-      },
-      "Coordinate" : [
-         {
-            "@type" : [
-               "Location",
-               "Entity"
-            ],
-            "nidm:NIDM_0000086" : "[ 45, -40, 32 ]",
-            "@id" : "niiri:coordinate_0009",
-            "rdfs:label" : "Coordinate: 0009"
-         },
-         {
-            "nidm:NIDM_0000086" : "[ 60, -22, 11 ]",
-            "@type" : [
-               "Location",
-               "Entity"
-            ],
-            "rdfs:label" : "Coordinate: 0005",
-            "@id" : "niiri:coordinate_0005"
-         },
-         {
-            "@type" : [
-               "Location",
-               "Entity"
-            ],
-            "nidm:NIDM_0000086" : "[ -60, -25, 11 ]",
-            "@id" : "niiri:coordinate_0001",
-            "rdfs:label" : "Coordinate: 0001"
-         },
-         {
-            "nidm:NIDM_0000086" : "[ 63, -13, -4 ]",
-            "@type" : [
-               "Location",
-               "Entity"
-            ],
-            "rdfs:label" : "Coordinate: 0004",
-            "@id" : "niiri:coordinate_0004"
-         },
-         {
-            "@id" : "niiri:coordinate_0003",
-            "rdfs:label" : "Coordinate: 0003",
-            "@type" : [
-               "Location",
-               "Entity"
-            ],
-            "nidm:NIDM_0000086" : "[ -66, -31, -1 ]"
-         }
-      ]
-   },
-   "@id" : "https://raw.githubusercontent.com/incf-nidash/nidm-specs/master/nidm/nidm-results/spm/example001/example001_spm_results.ttl",
-   "@context" : "https://raw.githubusercontent.com/satra/nidm-jsonld/master/nidm-results.jsonld"
+      "searchVolumeInUnits": "1771011.0",
+      "dct:format": "image/nifti"
+    },
+    "spm": {
+      "rdfs:label": "spm_results_nidm",
+      "nidm:NIDM_0000122": "12b.5858",
+      "@id": "niiri:exporter_id"
+    }
+  }
 }
 """
 

--- a/datalad_neuroimaging/extractors/tests/test_nidmresults.py
+++ b/datalad_neuroimaging/extractors/tests/test_nidmresults.py
@@ -20,129 +20,783 @@ from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_result_count
 
 
-# TODO update when format changes to a compacted JSON-LD form
 example_metadata = """\
 {
-    "NIDMResultsExporter_type": "spm_results_nidm",
-    "NIDMResultsExporter_softwareVersion": "12.7057",
-    "NIDMResults_version": "1.3.0",
-    "NeuroimagingAnalysisSoftware_type": "scr_SPM",
-    "NeuroimagingAnalysisSoftware_label": "SPM",
-    "NeuroimagingAnalysisSoftware_softwareVersion": "12.7219",
-    "ImagingInstrument_type": "nlx_MagneticResonanceImagingScanner",
-    "Data_grandMeanScaling": true,
-    "Data_targetIntensity": 100,
-    "Data_hasMRIProtocol": "nlx_FunctionalMRIProtocol",
-    "ParameterEstimateMaps": [
-        "/test/data/nidmresults-examples/spm_full_example001/beta_0001.nii",
-        "/test/data/nidmresults-examples/spm_full_example001/beta_0002.nii"
-    ],
-    "ResidualMeanSquaresMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/ResMS.nii",
-    "ReselsPerVoxelMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/RPV.nii",
-    "Contrasts": {
-        "StatisticMap_contrastName": "passive listening > rest",
-        "ContrastWeightMatrix_value": [1,0],
-        "StatisticMap_statisticType": "obo_TStatistic",
-        "StatisticMap_errorDegreesOfFreedom": 83.9999999999599,
-        "ContrastStandardErrorMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/ContrastStandardError.nii.gz"
-    },
-    "ClusterDefinitionCriteria_hasConnectivityCriterion": "nidm_voxel18connected",
-    "PeakDefinitionCriteria_minDistanceBetweenPeaks": 8,
-    "PeakDefinitionCriteria_maxNumberOfPeaksPerCluster": 3,
-    "Inferences": {
-        "HeightThreshold_type": "obo_FWERAdjustedPValue",
-        "HeightThreshold_value": 0.0499999999999976,
-        "ExtentThreshold_type": "obo_Statistic",
-        "ExtentThreshold_clusterSizeInVoxels": 0,
-        "ExtentThreshold_clusterSizeInResels": 0,
-        "HeightThreshold_equivalentThreshold": [
-            {
-                "HeightThreshold_type": "obo_Statistic",
-                "HeightThreshold_value": 4.852417456895391
+   "records" : {
+      "SupraThresholdCluster" : [
+         {
+            "@id" : "niiri:supra_threshold_cluster_0001",
+            "clusterSizeInResels" : "6.31265696809113",
+            "qValueFDR" : "1.77948412240239e-18",
+            "rdfs:label" : "Supra-Threshold Cluster: 0001",
+            "clusterLabelId" : "1",
+            "@type" : "Entity",
+            "clusterSizeInVoxels" : "839",
+            "pValueUncorrected" : "3.55896824480477e-19",
+            "pValueFWER" : "0.0",
+            "wasDerivedFrom" : "niiri:excursion_set_map_id"
+         },
+         {
+            "pValueFWER" : "0.0",
+            "pValueUncorrected" : "5.34280282632073e-17",
+            "clusterSizeInVoxels" : "695",
+            "wasDerivedFrom" : "niiri:excursion_set_map_id",
+            "qValueFDR" : "1.33570070658018e-16",
+            "rdfs:label" : "Supra-Threshold Cluster: 0002",
+            "clusterLabelId" : "2",
+            "@id" : "niiri:supra_threshold_cluster_0002",
+            "clusterSizeInResels" : "5.22919736927692",
+            "@type" : "Entity"
+         }
+      ],
+      "FWERadjustedpvalue" : [
+         {
+            "@id" : "niiri:height_threshold_id",
+            "rdfs:label" : "Height Threshold: p<0.050000 (FWE)",
+            "prov:value" : {
+               "@value" : "0.05",
+               "@type" : "xsd:float"
             },
-            {
-                "HeightThreshold_type": "nidm_PValueUncorrected",
-                "HeightThreshold_value": 2.7772578456986e-06
-            }
-        ],
-        "ExtentThreshold_equivalentThreshold": [
-            {
-                "ExtentThreshold_type": "obo_FWERAdjustedPValue",
-                "ExtentThreshold_value": 1
+            "@type" : [
+               "HeightThreshold",
+               "Entity"
+            ],
+            "equivalentThreshold" : [
+               "niiri:height_threshold_id_3",
+               "niiri:height_threshold_id_2"
+            ]
+         },
+         {
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "1.0"
             },
-            {
-                "ExtentThreshold_type": "nidm_PValueUncorrected",
-                "ExtentThreshold_value": 1
-            }
-        ],
-        "Inference_hasAlternativeHypothesis": "nidm_OneTailedTest",
-        "StatisticMap_contrastName": ["passive listening > rest"],
-        "ExcursionSetMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/ExcursionSet.nii.gz",
-        "ExcursionSetMap_numberOfSupraThresholdClusters": 5,
-        "ExcursionSetMap_pValue": 2.835106815979316e-09,
-        "ClusterLabelsMap_atLocation": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/ClusterLabels.nii.gz",
-        "ExcursionSetMap_hasMaximumIntensityProjection": "/test/data/nidmresults-examples/spm_full_example001/oct-p80GGE/MaximumIntensityProjection.png",
-        "Clusters": [
-            {
-                "SupraThresholdCluster_clusterSizeInVoxels": 839,
-                "SupraThresholdCluster_clusterSizeInResels": 6.312656968091135,
-                "SupraThresholdCluster_pValueUncorrected": 3.558968244804772e-19,
-                "SupraThresholdCluster_pValueFWER": 0,
-                "SupraThresholdCluster_qValueFDR": 1.779484122402386e-18,
-                "Peaks": [
-                    {
-                        "Peak_value": 17.5207633972168,
-                        "Coordinate_coordinateVector": [-60,-25,11],
-                        "Peak_pValueUncorrected": 4.440892098500626e-16,
-                        "Peak_equivalentZStatistic": null,
-                        "Peak_pValueFWER": 0,
-                        "Peak_qValueFDR": 1.191565917138381e-11
-                    },
-                    {
-                        "Peak_value": 13.03214073181152,
-                        "Coordinate_coordinateVector": [-42,-31,11],
-                        "Peak_pValueUncorrected": 4.440892098500626e-16,
-                        "Peak_equivalentZStatistic": null,
-                        "Peak_pValueFWER": 0,
-                        "Peak_qValueFDR": 1.191565917138381e-11
-                    },
-                    {
-                        "Peak_value": 10.28560161590576,
-                        "Coordinate_coordinateVector": [-66,-31,-1],
-                        "Peak_pValueUncorrected": 4.440892098500626e-16,
-                        "Peak_equivalentZStatistic": null,
-                        "Peak_pValueFWER": 7.69451169446711e-12,
-                        "Peak_qValueFDR": 6.841212602749916e-10
-                    }
-                ]
+            "@type" : [
+               "Entity",
+               "ExtentThreshold"
+            ],
+            "rdfs:label" : "Extent Threshold",
+            "@id" : "niiri:extent_threshold_id_2"
+         }
+      ],
+      "PValueUncorrected" : {
+         "@type" : [
+            "ExtentThreshold",
+            "Entity"
+         ],
+         "prov:value" : {
+            "@value" : "1.0",
+            "@type" : "xsd:float"
+         },
+         "rdfs:label" : "Extent Threshold",
+         "@id" : "niiri:extent_threshold_id_3"
+      },
+      "StatisticMap" : [
+         {
+            "@type" : "Entity",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "rdfs:label" : "T-Statistic Map: passive listening > rest",
+            "effectDegreesOfFreedom" : "1.0",
+            "@id" : "niiri:statistic_map_id",
+            "wasDerivedFrom" : "niiri:statistic_map_id_der",
+            "location" : "TStatistic.nii.gz",
+            "dct:format" : "image/nifti",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6",
+            "statisticType" : "http://purl.obolibrary.org/obo/STATO_0000176",
+            "wasGeneratedBy" : "niiri:contrast_estimation_id",
+            "nidm:NIDM_0000085" : "passive listening > rest",
+            "nfo:fileName" : "TStatistic.nii.gz",
+            "errorDegreesOfFreedom" : "84.0"
+         },
+         {
+            "dct:format" : "image/nifti",
+            "@type" : "Entity",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825",
+            "nfo:fileName" : "spmT_0001.nii",
+            "@id" : "niiri:statistic_map_id_der"
+         }
+      ],
+      "Location" : [
+         {
+            "@id" : "niiri:coordinate_0007",
+            "rdfs:label" : "Coordinate: 0007",
+            "@type" : [
+               "Coordinate",
+               "Entity"
+            ],
+            "nidm:NIDM_0000086" : "[ 36, -28, -13 ]"
+         },
+         {
+            "nidm:NIDM_0000086" : "[ -42, -31, 11 ]",
+            "@type" : [
+               "Coordinate",
+               "Entity"
+            ],
+            "rdfs:label" : "Coordinate: 0002",
+            "@id" : "niiri:coordinate_0002"
+         },
+         {
+            "@type" : [
+               "Coordinate",
+               "Entity"
+            ],
+            "nidm:NIDM_0000086" : "[ 57, -40, 5 ]",
+            "@id" : "niiri:coordinate_0006",
+            "rdfs:label" : "Coordinate: 0006"
+         }
+      ],
+      "Magneticresonanceimagingscanner" : {
+         "rdfs:label" : "MRI Scanner",
+         "@id" : "niiri:mr_scanner_id",
+         "@type" : [
+            "Agent",
+            "Imaginginstrument"
+         ]
+      },
+      "DesignMatrix" : {
+         "dct:format" : "text/csv",
+         "location" : "DesignMatrix.csv",
+         "nfo:fileName" : "DesignMatrix.csv",
+         "@type" : "Entity",
+         "hasDriftModel" : "niiri:drift_model_id",
+         "nidm:NIDM_0000021" : "[\\"Sn(1) active*bf(1)\\", \\"Sn(1) constant\\"]",
+         "Description" : "niiri:design_matrix_png_id",
+         "@id" : "niiri:design_matrix_id",
+         "hasHRFBasis" : "spm:SPM_0000004",
+         "rdfs:label" : "Design Matrix"
+      },
+      "Person" : {
+         "@type" : "Agent",
+         "rdfs:label" : "Person",
+         "@id" : "niiri:subject_id"
+      },
+      "ContrastStandardErrorMap" : {
+         "nfo:fileName" : "ContrastStandardError.nii.gz",
+         "location" : "ContrastStandardError.nii.gz",
+         "dct:format" : "image/nifti",
+         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2",
+         "wasGeneratedBy" : "niiri:contrast_estimation_id",
+         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+         "rdfs:label" : "Contrast Standard Error Map",
+         "@id" : "niiri:contrast_standard_error_map_id",
+         "@type" : "Entity"
+      },
+      "Activity" : [
+         {
+            "@type" : "ContrastEstimation",
+            "used" : [
+               "niiri:design_matrix_id",
+               "niiri:contrast_id",
+               "niiri:beta_map_id_1",
+               "niiri:residual_mean_squares_map_id",
+               "niiri:mask_id_1",
+               "niiri:beta_map_id_2"
+            ],
+            "rdfs:label" : "Contrast estimation",
+            "wasAssociatedWith" : "niiri:software_id",
+            "@id" : "niiri:contrast_estimation_id"
+         },
+         {
+            "@type" : "NIDMResultsExport",
+            "rdfs:label" : "NIDM-Results export",
+            "@id" : "niiri:export_id",
+            "wasAssociatedWith" : "niiri:exporter_id"
+         },
+         {
+            "@type" : "Inference",
+            "used" : [
+               "niiri:statistic_map_id",
+               "niiri:height_threshold_id",
+               "niiri:cluster_definition_criteria_id",
+               "niiri:resels_per_voxel_map_id",
+               "niiri:extent_threshold_id",
+               "niiri:mask_id_1",
+               "niiri:peak_definition_criteria_id"
+            ],
+            "hasAlternativeHypothesis" : "nidm:NIDM_0000060",
+            "wasAssociatedWith" : "niiri:software_id",
+            "@id" : "niiri:inference_id",
+            "rdfs:label" : "Inference"
+         }
+      ],
+      "ClusterLabelsMap" : {
+         "@type" : "Entity",
+         "@id" : "niiri:cluster_label_map_id",
+         "rdfs:label" : "Cluster Labels Map",
+         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a311a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3",
+         "dct:format" : "image/nifti",
+         "location" : "ClusterLabels.nii.gz",
+         "nfo:fileName" : "ClusterLabels.nii.gz"
+      },
+      "ErrorModel" : {
+         "hasErrorDistribution" : "http://purl.obolibrary.org/obo/STATO_0000227",
+         "@type" : "Entity",
+         "nidm:NIDM_0000094" : true,
+         "hasErrorDependence" : "http://purl.obolibrary.org/obo/STATO_0000357",
+         "@id" : "niiri:error_model_id",
+         "dependenceMapWiseDependence" : "nidm:NIDM_0000072",
+         "varianceMapWiseDependence" : "nidm:NIDM_0000073"
+      },
+      "Agent" : {
+         "@type" : [
+            "SoftwareAgent",
+            "SPM"
+         ],
+         "softwareVersion" : "12.12.1",
+         "rdfs:label" : "SPM",
+         "@id" : "niiri:software_id"
+      },
+      "Peak" : [
+         {
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0001",
+            "pValueUncorrected" : "4.44089209850063e-16",
+            "pValueFWER" : "7.69451169446711e-12",
+            "equivalentZStatistic" : "inf",
+            "atLocation" : "niiri:coordinate_0003",
+            "@type" : "Entity",
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "10.2856016159058"
             },
-            {
-                "SupraThresholdCluster_clusterSizeInVoxels": 695,
-                "SupraThresholdCluster_clusterSizeInResels": 5.229197369276923,
-                "SupraThresholdCluster_pValueUncorrected": 5.342802826320728e-17,
-                "SupraThresholdCluster_pValueFWER": 0,
-                "SupraThresholdCluster_qValueFDR": 1.335700706580182e-16,
-                "Peaks": [
-                    {
-                        "Peak_value": 13.54255771636963,
-                        "Coordinate_coordinateVector": [63,-13,-4],
-                        "Peak_pValueUncorrected": 4.440892098500626e-16,
-                        "Peak_equivalentZStatistic": null,
-                        "Peak_pValueFWER": 0,
-                        "Peak_qValueFDR": 1.191565917138381e-11
-                    },
-                    {
-                        "Peak_value": 12.47287178039551,
-                        "Coordinate_coordinateVector": [60,-22,11],
-                        "Peak_pValueUncorrected": 4.440892098500626e-16,
-                        "Peak_equivalentZStatistic": null,
-                        "Peak_pValueFWER": 0,
-                        "Peak_qValueFDR": 1.191565917138381e-11
-                    }
-                ]
+            "@id" : "niiri:peak_0003",
+            "qValueFDR" : "6.84121260274992e-10",
+            "rdfs:label" : "Peak: 0003"
+         },
+         {
+            "pValueFWER" : "6.9250605250204e-11",
+            "equivalentZStatistic" : "inf",
+            "pValueUncorrected" : "1.22124532708767e-15",
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0002",
+            "qValueFDR" : "6.52169693024352e-09",
+            "rdfs:label" : "Peak: 0006",
+            "@id" : "niiri:peak_0006",
+            "atLocation" : "niiri:coordinate_0006",
+            "@type" : "Entity",
+            "prov:value" : {
+               "@value" : "9.72103404998779",
+               "@type" : "xsd:float"
             }
-        ]
-    }
+         },
+         {
+            "prov:value" : {
+               "@value" : "5.27320194244385",
+               "@type" : "xsd:float"
+            },
+            "atLocation" : "niiri:coordinate_0009",
+            "@type" : "Entity",
+            "rdfs:label" : "Peak: 0009",
+            "qValueFDR" : "0.251554254717758",
+            "@id" : "niiri:peak_0009",
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0005",
+            "equivalentZStatistic" : "4.88682085490477",
+            "pValueFWER" : "0.0119099090973821",
+            "pValueUncorrected" : "5.12386299833523e-07"
+         }
+      ],
+      "ParameterEstimateMap" : [
+         {
+            "@id" : "niiri:beta_map_id_2_der",
+            "nfo:fileName" : "beta_0002.nii",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
+            "@type" : "Entity",
+            "dct:format" : "image/nifti"
+         },
+         {
+            "dct:format" : "image/nifti",
+            "@type" : "Entity",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
+            "nfo:fileName" : "beta_0001.nii",
+            "@id" : "niiri:beta_map_id_1_der"
+         }
+      ],
+      "ContrastMap" : {
+         "nfo:fileName" : "Contrast.nii.gz",
+         "location" : "Contrast.nii.gz",
+         "wasDerivedFrom" : "niiri:contrast_map_id_der",
+         "dct:format" : "image/nifti",
+         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2",
+         "nidm:NIDM_0000085" : "passive listening > rest",
+         "wasGeneratedBy" : "niiri:contrast_estimation_id",
+         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+         "rdfs:label" : "Contrast Map: passive listening > rest",
+         "@id" : "niiri:contrast_map_id",
+         "@type" : "Entity"
+      },
+      "ModelParameterEstimation" : {
+         "wasAssociatedWith" : "niiri:software_id",
+         "@id" : "niiri:model_pe_id",
+         "withEstimationMethod" : "http://purl.obolibrary.org/obo/STATO_0000372",
+         "rdfs:label" : "Model parameters estimation",
+         "@type" : "Activity",
+         "used" : [
+            "niiri:data_id",
+            "niiri:error_model_id",
+            "niiri:design_matrix_id"
+         ]
+      },
+      "HeightThreshold" : [
+         {
+            "@type" : [
+               "Entity",
+               "statistic"
+            ],
+            "prov:value" : {
+               "@value" : "4.85241745689539",
+               "@type" : "xsd:float"
+            },
+            "rdfs:label" : "Height Threshold",
+            "@id" : "niiri:height_threshold_id_2"
+         },
+         {
+            "@id" : "niiri:height_threshold_id_3",
+            "rdfs:label" : "Height Threshold",
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "2.7772578456986e-06"
+            },
+            "@type" : [
+               "Entity",
+               "PValueUncorrected"
+            ]
+         }
+      ],
+      "SoftwareAgent" : {
+         "@id" : "niiri:exporter_id",
+         "rdfs:label" : "spm_results_nidm",
+         "@type" : [
+            "spm_results_nidm",
+            "Agent"
+         ],
+         "softwareVersion" : "12b.5858"
+      },
+      "Entity" : [
+         {
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "6.19558477401733"
+            },
+            "atLocation" : "niiri:coordinate_0008",
+            "@type" : "Peak",
+            "@id" : "niiri:peak_0008",
+            "qValueFDR" : "0.00949154522981781",
+            "rdfs:label" : "Peak: 0008",
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0004",
+            "pValueUncorrected" : "1.0325913235576e-08",
+            "equivalentZStatistic" : "5.60645028016544",
+            "pValueFWER" : "0.000382453907303626"
+         },
+         {
+            "nfo:fileName" : "GrandMean.nii.gz",
+            "maskedMedian" : "132.008995056152",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb",
+            "wasGeneratedBy" : "niiri:model_pe_id",
+            "location" : "GrandMean.nii.gz",
+            "dct:format" : "image/nifti",
+            "@id" : "niiri:grand_mean_map_id",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "rdfs:label" : "Grand Mean Map",
+            "@type" : "GrandMeanMap"
+         },
+         {
+            "@id" : "niiri:resels_per_voxel_map_id_der",
+            "nfo:fileName" : "RPV.nii",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d",
+            "@type" : "ReselsPerVoxelMap",
+            "dct:format" : "image/nifti"
+         },
+         {
+            "numberOfDimensions" : "3",
+            "nidm:NIDM_0000090" : "[ 53, 63, 52 ]",
+            "nidm:NIDM_0000132" : "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]",
+            "rdfs:label" : "Coordinate space 1",
+            "@id" : "niiri:coordinate_space_id_1",
+            "inWorldCoordinateSystem" : "nidm:NIDM_0000050",
+            "nidm:NIDM_0000131" : "[ 3, 3, 3 ]",
+            "nidm:NIDM_0000133" : "[ \\"mm\\", \\"mm\\", \\"mm\\" ]",
+            "@type" : "CoordinateSpace"
+         },
+         {
+            "nfo:fileName" : "mask.nii",
+            "@id" : "niiri:mask_id_1_der",
+            "dct:format" : "image/nifti",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11",
+            "@type" : "MaskMap"
+         },
+         {
+            "rdfs:label" : "Cluster Connectivity Criterion: 18",
+            "@id" : "niiri:cluster_definition_criteria_id",
+            "@type" : "ClusterDefinitionCriteria",
+            "hasConnectivityCriterion" : "nidm:NIDM_0000128"
+         },
+         {
+            "@type" : "ReselsPerVoxelMap",
+            "@id" : "niiri:resels_per_voxel_map_id",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "rdfs:label" : "Resels per Voxel Map",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a",
+            "wasGeneratedBy" : "niiri:model_pe_id",
+            "location" : "ReselsPerVoxel.nii.gz",
+            "wasDerivedFrom" : "niiri:resels_per_voxel_map_id_der",
+            "dct:format" : "image/nifti",
+            "nfo:fileName" : "ReselsPerVoxel.nii.gz"
+         },
+         {
+            "nidm:NIDM_0000085" : "passive listening > rest",
+            "@type" : "contrastweightmatrix",
+            "prov:value" : "[1, 0]",
+            "statisticType" : "http://purl.obolibrary.org/obo/STATO_0000176",
+            "@id" : "niiri:contrast_id",
+            "rdfs:label" : "Contrast: passive listening > rest"
+         },
+         {
+            "nfo:fileName" : "con_0001.nii",
+            "@id" : "niiri:contrast_map_id_der",
+            "dct:format" : "image/nifti",
+            "@type" : "ContrastMap",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22"
+         },
+         {
+            "wasDerivedFrom" : "niiri:excursion_set_map_id",
+            "clusterSizeInVoxels" : "29",
+            "pValueUncorrected" : "0.0110257032104773",
+            "pValueFWER" : "0.000565384750377596",
+            "@type" : "SupraThresholdCluster",
+            "clusterSizeInResels" : "0.218196724761195",
+            "@id" : "niiri:supra_threshold_cluster_0004",
+            "rdfs:label" : "Supra-Threshold Cluster: 0004",
+            "qValueFDR" : "0.0137821290130967",
+            "clusterLabelId" : "4"
+         },
+         {
+            "qValueFDR" : "0.00257605396646668",
+            "rdfs:label" : "Peak: 0007",
+            "@id" : "niiri:peak_0007",
+            "@type" : "Peak",
+            "atLocation" : "niiri:coordinate_0007",
+            "prov:value" : {
+               "@value" : "6.55745935440063",
+               "@type" : "xsd:float"
+            },
+            "equivalentZStatistic" : "5.87574033699266",
+            "pValueFWER" : "9.17574302586877e-05",
+            "pValueUncorrected" : "2.10478867668229e-09",
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0003"
+         },
+         {
+            "location" : "DesignMatrix.png",
+            "dct:format" : "image/png",
+            "@type" : "http://purl.org/dc/dcmitype/Image",
+            "nfo:fileName" : "DesignMatrix.png",
+            "@id" : "niiri:design_matrix_png_id"
+         },
+         {
+            "rdfs:label" : "Coordinate: 0008",
+            "@id" : "niiri:coordinate_0008",
+            "nidm:NIDM_0000086" : "[ -33, -31, -16 ]",
+            "@type" : [
+               "Location",
+               "Coordinate"
+            ]
+         },
+         {
+            "nfo:fileName" : "ExcursionSet.nii.gz",
+            "hasMaximumIntensityProjection" : "niiri:maximum_intensity_projection_id",
+            "numberOfSupraThresholdClusters" : "5",
+            "hasClusterLabelsMap" : "niiri:cluster_label_map_id",
+            "dct:format" : "image/nifti",
+            "location" : "ExcursionSet.nii.gz",
+            "wasGeneratedBy" : "niiri:inference_id",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652",
+            "rdfs:label" : "Excursion Set Map",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "@id" : "niiri:excursion_set_map_id",
+            "@type" : "ExcursionSetMap",
+            "pValue" : "2.83510681598e-09"
+         },
+         {
+            "@type" : "ResidualMeanSquaresMap",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd",
+            "dct:format" : "image/nifti",
+            "@id" : "niiri:residual_mean_squares_map_id_der",
+            "nfo:fileName" : "ResMS.nii"
+         },
+         {
+            "@type" : [
+               "NIDMResults",
+               "Bundle"
+            ],
+            "nidm:NIDM_0000127" : "1.3.0",
+            "@id" : "niiri:spm_results_id",
+            "qualifiedGeneration" : "_:f1b4bd76338a04597b3f698e59f695e53b1",
+            "rdfs:label" : "NIDM-Results"
+         },
+         {
+            "pValueUncorrected" : "4.44089209850063e-16",
+            "pValueFWER" : "0.0",
+            "equivalentZStatistic" : "inf",
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0002",
+            "@id" : "niiri:peak_0005",
+            "qValueFDR" : "1.19156591713838e-11",
+            "rdfs:label" : "Peak: 0005",
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "12.4728717803955"
+            },
+            "@type" : "Peak",
+            "atLocation" : "niiri:coordinate_0005"
+         },
+         {
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0002",
+            "pValueUncorrected" : "4.44089209850063e-16",
+            "equivalentZStatistic" : "inf",
+            "pValueFWER" : "0.0",
+            "atLocation" : "niiri:coordinate_0004",
+            "@type" : "Peak",
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "13.5425577163696"
+            },
+            "@id" : "niiri:peak_0004",
+            "rdfs:label" : "Peak: 0004",
+            "qValueFDR" : "1.19156591713838e-11"
+         },
+         {
+            "nfo:fileName" : "ResidualMeanSquares.nii.gz",
+            "wasDerivedFrom" : "niiri:residual_mean_squares_map_id_der",
+            "location" : "ResidualMeanSquares.nii.gz",
+            "dct:format" : "image/nifti",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b",
+            "wasGeneratedBy" : "niiri:model_pe_id",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "rdfs:label" : "Residual Mean Squares Map",
+            "@id" : "niiri:residual_mean_squares_map_id",
+            "@type" : "ResidualMeanSquaresMap"
+         },
+         {
+            "@type" : "DiscreteCosineTransformbasisDriftModel",
+            "rdfs:label" : "SPM's DCT Drift Model",
+            "spm:SPM_0000001" : {
+               "@type" : "xsd:float",
+               "@value" : "128.0"
+            },
+            "@id" : "niiri:drift_model_id"
+         },
+         {
+            "equivalentZStatistic" : "inf",
+            "pValueFWER" : "0.0",
+            "pValueUncorrected" : "4.44089209850063e-16",
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0001",
+            "qValueFDR" : "1.19156591713838e-11",
+            "rdfs:label" : "Peak: 0001",
+            "@id" : "niiri:peak_0001",
+            "prov:value" : {
+               "@value" : "17.5207633972168",
+               "@type" : "xsd:float"
+            },
+            "atLocation" : "niiri:coordinate_0001",
+            "@type" : "Peak"
+         },
+         {
+            "dct:format" : "image/png",
+            "location" : "MaximumIntensityProjection.png",
+            "@type" : "http://purl.org/dc/dcmitype/Image",
+            "nfo:fileName" : "MaximumIntensityProjection.png",
+            "@id" : "niiri:maximum_intensity_projection_id"
+         },
+         {
+            "pValueUncorrected" : "0.0818393184514307",
+            "clusterSizeInVoxels" : "12",
+            "pValueFWER" : "0.00418900977248904",
+            "wasDerivedFrom" : "niiri:excursion_set_map_id",
+            "@id" : "niiri:supra_threshold_cluster_0005",
+            "clusterSizeInResels" : "0.0902882999011843",
+            "clusterLabelId" : "5",
+            "rdfs:label" : "Supra-Threshold Cluster: 0005",
+            "qValueFDR" : "0.0818393184514307",
+            "@type" : "SupraThresholdCluster"
+         },
+         {
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
+            "wasGeneratedBy" : "niiri:model_pe_id",
+            "wasDerivedFrom" : "niiri:beta_map_id_2_der",
+            "location" : "ParameterEstimate_0002.nii.gz",
+            "dct:format" : "image/nifti",
+            "nfo:fileName" : "ParameterEstimate_0002.nii.gz",
+            "@type" : "ParameterEstimateMap",
+            "@id" : "niiri:beta_map_id_2",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "rdfs:label" : "Parameter Estimate Map 2"
+         },
+         {
+            "@id" : "niiri:peak_definition_criteria_id",
+            "rdfs:label" : "Peak Definition Criteria",
+            "minDistanceBetweenPeaks" : "8.0",
+            "maxNumberOfPeaksPerCluster" : "3",
+            "@type" : "PeakDefinitionCriteria"
+         },
+         {
+            "@type" : "ParameterEstimateMap",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "rdfs:label" : "Parameter Estimate Map 1",
+            "@id" : "niiri:beta_map_id_1",
+            "location" : "ParameterEstimate_0001.nii.gz",
+            "wasDerivedFrom" : "niiri:beta_map_id_1_der",
+            "dct:format" : "image/nifti",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
+            "wasGeneratedBy" : "niiri:model_pe_id",
+            "nfo:fileName" : "ParameterEstimate_0001.nii.gz"
+         },
+         {
+            "smallestSignificantClusterSizeInVoxelsFWE05" : "12",
+            "expectedNumberOfVoxelsPerCluster" : "4.02834655908613",
+            "nidm:NIDM_0000157" : "[ 16.2383695773208, 16.3091687172086, 13.5499997663244 ]",
+            "@id" : "niiri:search_space_mask_id",
+            "dct:format" : "image/nifti",
+            "reselSizeInVoxels" : "132.907586178202",
+            "searchVolumeInVoxels" : "69306",
+            "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
+            "smallestSignificantClusterSizeInVoxelsFDR05" : "29",
+            "heightCriticalThresholdFWE05" : "4.85241745689539",
+            "@type" : "SearchSpaceMaskMap",
+            "rdfs:label" : "Search Space Mask Map",
+            "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+            "searchVolumeInResels" : "467.07642343881",
+            "nidm:NIDM_0000120" : true,
+            "location" : "SearchSpaceMask.nii.gz",
+            "nidm:NIDM_0000159" : "[ 5.41278985910694, 5.43638957240286, 4.51666658877481 ]",
+            "wasGeneratedBy" : "niiri:inference_id",
+            "expectedNumberOfClusters" : "0.0512932943875478",
+            "spm:SPM_0000010" : "[7, 42.96312274763, 269.40914815306, 467.07642343881]",
+            "nfo:fileName" : "SearchSpaceMask.nii.gz",
+            "heightCriticalThresholdFDR05" : "5.7639536857605",
+            "searchVolumeInUnits" : "1871262.0"
+         },
+         {
+            "@id" : "niiri:supra_threshold_cluster_0003",
+            "clusterSizeInResels" : "0.278388924695318",
+            "rdfs:label" : "Supra-Threshold Cluster: 0003",
+            "qValueFDR" : "0.00829922079256674",
+            "clusterLabelId" : "3",
+            "@type" : "SupraThresholdCluster",
+            "pValueUncorrected" : "0.00497953247554004",
+            "clusterSizeInVoxels" : "37",
+            "pValueFWER" : "0.000255384009130943",
+            "wasDerivedFrom" : "niiri:excursion_set_map_id"
+         },
+         {
+            "wasDerivedFrom" : "niiri:supra_threshold_cluster_0001",
+            "pValueUncorrected" : "4.44089209850063e-16",
+            "pValueFWER" : "0.0",
+            "equivalentZStatistic" : "inf",
+            "@type" : "Peak",
+            "atLocation" : "niiri:coordinate_0002",
+            "prov:value" : {
+               "@type" : "xsd:float",
+               "@value" : "13.0321407318"
+            },
+            "@id" : "niiri:peak_0002",
+            "qValueFDR" : "1.19156591714e-11",
+            "rdfs:label" : "Peak: 0002"
+         }
+      ],
+      "ExtentThreshold" : {
+         "@type" : [
+            "statistic",
+            "Entity"
+         ],
+         "equivalentThreshold" : [
+            "niiri:extent_threshold_id_2",
+            "niiri:extent_threshold_id_3"
+         ],
+         "@id" : "niiri:extent_threshold_id",
+         "clusterSizeInResels" : "0.0",
+         "clusterSizeInVoxels" : "0",
+         "rdfs:label" : "Extent Threshold: k>=0"
+      },
+      "MaskMap" : {
+         "@type" : "Entity",
+         "inCoordinateSpace" : "niiri:coordinate_space_id_1",
+         "rdfs:label" : "Mask",
+         "@id" : "niiri:mask_id_1",
+         "wasDerivedFrom" : "niiri:mask_id_1_der",
+         "location" : "Mask.nii.gz",
+         "dct:format" : "image/nifti",
+         "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#sha512" : "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
+         "wasGeneratedBy" : "niiri:model_pe_id",
+         "nidm:NIDM_0000106" : false,
+         "nfo:fileName" : "Mask.nii.gz"
+      },
+      "Generation" : {
+         "activity" : "niiri:export_id",
+         "atTime" : "2014-05-19T10:30:00+01:00",
+         "@id" : "_:f1b4bd76338a04597b3f698e59f695e53b1"
+      },
+      "Collection" : {
+         "hasMRIProtocol" : "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+         "@id" : "niiri:data_id",
+         "targetIntensity" : "100.0",
+         "wasAttributedTo" : [
+            "niiri:subject_id",
+            "niiri:mr_scanner_id"
+         ],
+         "rdfs:label" : "Data",
+         "nidm:NIDM_0000096" : true,
+         "@type" : [
+            "Data",
+            "Entity"
+         ]
+      },
+      "Coordinate" : [
+         {
+            "@type" : [
+               "Location",
+               "Entity"
+            ],
+            "nidm:NIDM_0000086" : "[ 45, -40, 32 ]",
+            "@id" : "niiri:coordinate_0009",
+            "rdfs:label" : "Coordinate: 0009"
+         },
+         {
+            "nidm:NIDM_0000086" : "[ 60, -22, 11 ]",
+            "@type" : [
+               "Location",
+               "Entity"
+            ],
+            "rdfs:label" : "Coordinate: 0005",
+            "@id" : "niiri:coordinate_0005"
+         },
+         {
+            "@type" : [
+               "Location",
+               "Entity"
+            ],
+            "nidm:NIDM_0000086" : "[ -60, -25, 11 ]",
+            "@id" : "niiri:coordinate_0001",
+            "rdfs:label" : "Coordinate: 0001"
+         },
+         {
+            "nidm:NIDM_0000086" : "[ 63, -13, -4 ]",
+            "@type" : [
+               "Location",
+               "Entity"
+            ],
+            "rdfs:label" : "Coordinate: 0004",
+            "@id" : "niiri:coordinate_0004"
+         },
+         {
+            "@id" : "niiri:coordinate_0003",
+            "rdfs:label" : "Coordinate: 0003",
+            "@type" : [
+               "Location",
+               "Entity"
+            ],
+            "nidm:NIDM_0000086" : "[ -66, -31, -1 ]"
+         }
+      ]
+   },
+   "@id" : "https://raw.githubusercontent.com/incf-nidash/nidm-specs/master/nidm/nidm-results/spm/example001/example001_spm_results.ttl",
+   "@context" : "https://raw.githubusercontent.com/satra/nidm-jsonld/master/nidm-results.jsonld"
 }
 """
 
@@ -178,5 +832,5 @@ def test_nidm(packpath, dspath):
         'nidmresults',
         res['metadata']['datalad_unique_content_properties'])
     assert_in(
-        'Contrasts',
+        'records',
         res['metadata']['datalad_unique_content_properties']['nidmresults'])

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
             'bids=datalad_neuroimaging.extractors.bids:MetadataExtractor',
             'dicom=datalad_neuroimaging.extractors.dicom:MetadataExtractor',
             'nidm=datalad_neuroimaging.extractors.nidm:MetadataExtractor',
+            'nidmresults=datalad_neuroimaging.extractors.nidmresults:MetadataExtractor',
             'nifti1=datalad_neuroimaging.extractors.nifti1:MetadataExtractor',
         ],
         'datalad.tests': [


### PR DESCRIPTION
Quick draft of a NIDM result metadata extractor. This is using a JSON-LD representation as input that is not very suitable for the search implementations we have.

- [x] RF this to use an alternative representation outlined in https://github.com/datalad/datalad/issues/2753
- [x] document queries that can be performed with the existing search implementation based on the extractor output -> https://github.com/datalad/datalad/issues/2753
- [x] tests