### PR TITLE
RF: make compatible also with recent pybids 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This is a high level and scarce summary of the changes between releases.  We
 would recommend to consult log of the [DataLad git
 repository](http://github.com/datalad/datalad-neuroimaging) for more details.
 
+## 0.2.0 (??? ??, 2019) -- ???
+
+- Make compatible with (and demand) pybids 0.7.0.  That version introduced
+  change of terms: modality -> suffix, and type -> datatype, which would now
+  require to either reaggregate all previous metadata or somehow fixup
+  in-place existing metadata files.
+
 ## 0.1.5 (Sep 28, 2018) -- BIDS robustness
 
 - Assorted improvements of the BIDS metadata extractor performance on datasets

--- a/datalad_neuroimaging/extractors/bids.py
+++ b/datalad_neuroimaging/extractors/bids.py
@@ -13,13 +13,7 @@ from math import isnan
 
 # use pybids to evolve with the standard without having to track it too much
 import bids
-try:
-    from bids import BIDSLayout
-except ImportError:
-    # in 0.7.0 .grabbids was deprecated but we keep this old way for
-    # compatibility for now
-    # TODO: prune whenver required pybids version exceeds 0.7.0
-    from bids.grabbids import BIDSLayout
+from bids import BIDSLayout
 
 import re
 from io import open
@@ -74,17 +68,8 @@ class MetadataExtractor(BaseMetadataExtractor):
     }
 
     def get_metadata(self, dataset, content):
-        # TODO: deprecate when bids 0.7.0 is required
-        derivs_path = opj(self.ds.path, 'derivatives')
         derivative_exist = exists(opj(self.ds.path, 'derivatives'))
-
-        if external_versions['bids'] >= '0.7.0':
-            bids = BIDSLayout(self.ds.path, derivatives=derivative_exist)
-        else:
-            paths = [(self.ds.path, 'bids')]
-            if derivative_exist:
-                paths.append((derivs_path, ['bids', 'derivatives']))
-            bids = BIDSLayout(paths)
+        bids = BIDSLayout(self.ds.path, derivatives=derivative_exist)
 
         dsmeta = self._get_dsmeta(bids)
 

--- a/datalad_neuroimaging/extractors/tests/test_bids.py
+++ b/datalad_neuroimaging/extractors/tests/test_bids.py
@@ -14,6 +14,7 @@ from simplejson import dumps
 from datalad.api import Dataset
 
 from nose.tools import assert_equal
+from datalad.support.external_versions import external_versions
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import assert_in
 
@@ -87,9 +88,13 @@ def test_get_metadata(path):
     # check that we get file props extracted from the file name from pybids
     fmeta = cmeta[0][1]
     assert_equal(fmeta['subject']['id'], '01')
-    assert_equal(fmeta['type'], 'bold')
+    # There was a RF from a restrictive "type" to a more generic, but more
+    # BIDS ad-hoc "suffix" lacking semantic value really in 0.7.0.
+    type_field = 'suffix' if external_versions['bids'] >= '0.7.0' else 'type'
+    assert_equal(fmeta[type_field], 'bold')
     assert_equal(fmeta['task'], 'some')
-    assert_equal(fmeta['modality'], 'func')
+    datatype_field = 'datatype' if external_versions['bids'] >= '0.7.0' else 'modality'
+    assert_equal(fmeta[datatype_field], 'func')
     # the fact that there is participant vs subject is already hotly debated in Tal's brain
     assert_in('handedness', fmeta['subject'])
     assert_in('language', fmeta['subject'])

--- a/datalad_neuroimaging/tests/test_search.py
+++ b/datalad_neuroimaging/tests/test_search.py
@@ -8,7 +8,9 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Some additional tests for search command"""
+import os
 
+from difflib import unified_diff
 from shutil import copy
 from os import makedirs
 from os.path import join as opj
@@ -106,14 +108,15 @@ type
 """, cmo.out)
 
     target_out = """\
+annex.key
 bids.BIDSVersion
 bids.author
 bids.citation
 bids.conformsto
+bids.datatype
 bids.description
 bids.fundedby
 bids.license
-bids.modality
 bids.name
 bids.subject.age(years)
 bids.subject.gender
@@ -121,8 +124,8 @@ bids.subject.handedness
 bids.subject.hearing_problems_current
 bids.subject.id
 bids.subject.language
+bids.suffix
 bids.task
-bids.type
 datalad_core.id
 datalad_core.refcommit
 id
@@ -159,7 +162,9 @@ type
     with swallow_outputs() as cmo:
         ds.search(mode='autofield', show_keys='name')
         # it is impossible to assess what is different from that dump
-        assert_in(target_out, cmo.out)
+        # so we will use diff
+        diff = list(unified_diff(target_out.splitlines(), cmo.out.splitlines()))
+        assert_in(target_out, cmo.out, msg="Diff: %s" % os.linesep.join(diff))
 
     assert_result_count(ds.search('blablob#'), 0)
     # now check that we can discover things from the aggregated metadata
@@ -177,9 +182,9 @@ type
              'bids.subject.gender', 'female'),
             # autofield multi-word query is also AND
             ('autofield',
-             ['bids.type:bold', 'bids.subject.id:01'],
+             ['bids.suffix:bold', 'bids.subject.id:01'],
              opj('sub-01', 'func', 'sub-01_task-some_bold.nii.gz'),
-             'bids.type', 'bold'),
+             'bids.suffix', 'bold'),
             # TODO extend with more complex queries to test whoosh
             # query language configuration
     ):

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'datalad[full]>=0.10.0.rc1',
         #'datalad-webapp',
         'pydicom',  # DICOM metadata
-        'pybids>=0.6.4',  # BIDS metadata
+        'pybids>=0.7.0',  # BIDS metadata
         'nibabel',  # NIfTI metadata
         'pandas',  # bids2scidata export
     ],


### PR DESCRIPTION
But having done it not sure if I we want to keep compatibility with
previuos versions since it is not only that API changed, but also their
annotation. At the least  "type" is now a non-specific "suffix", and
"modality" became a "datatype".  Whenever I am ok with "datatype",
loosing "type" is probably suboptimal although makes sense within
BIDS itself.

But having those changes in mind, it might be better to just demand
0.7.0 and remove compatibility layer.

Also I think it is time to start encoding some kind of "version" of
PyBIDS convention on top of what version of BIDS actual dataset
conforms with.  Since BIDS does not necessarily always gives corresponding
consistent namings aligned with PyBIDS I feel that we could still
have similar renamings in the future

Closes: #43