### PR TITLE
BF: revert to the original way of installing package data to install cfg_bids; test out of source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,10 @@ script:
   # Verify that setup.py build doesn't puke
   - python setup.py build
   # Test installation system-wide
-  - sudo pip install -e .
+  - sudo pip install .
   # Run tests
-  - http_proxy=
+  - cd build &&
+    http_proxy=
     PATH=$PWD/tools/coverage-bin:$PATH
     $NOSE_WRAPPER `which nosetests` $NOSE_OPTS
       -v -A "$NOSE_SELECTION_OP(integration or usecase or slow)"
@@ -72,6 +73,7 @@ script:
       --with-cov --cover-package datalad_neuroimaging
       --logging-level=INFO
       $TESTS_TO_PERFORM
+  - cd ..
   # Run doc examples
   - $NOSE_WRAPPER tools/testing/run_doc_examples
   - if [ ! "${DATALAD_LOG_LEVEL:-}" = 2 ]; then

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,11 @@ setup(
     ],
     extras_require=requires,
     cmdclass=cmdclass,
-    entry_points={
+    package_data={
+        'datalad_neuroimaging':
+            findsome(opj('tests', 'data', 'files'), {'dcm', 'gz'}) +
+            findsome('resources', {'py', 'txt'})},
+    entry_points = {
         # 'datalad.extensions' is THE entrypoint inspected by the datalad API builders
         'datalad.extensions': [
             # the label in front of '=' is the command suite label
@@ -105,5 +109,4 @@ setup(
             'neuroimaging=datalad_neuroimaging',
         ],
     },
-    include_package_data=True,
 )


### PR DESCRIPTION
- [x] RF: run tests as installed (not for development), from under build/ -- so we could catch installation breakage.  Want to first check that it would fail and then proceed to the next step
- [x] Partially revert which made it "simpler" but incorrect. `include_package_data=True` requires specification of the data files in `MANIFEST.in`.  Only hirni uses MANIFEST.in and I find it better for extensions to stay consistent with the core way of installing things. If we are to do it "simpler" way, we better adopt that strategy across code base.