### PR TITLE
RF: demand pybids >=0.9.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,8 @@ setup(
         'datalad>=0.11',
         #'datalad-webapp',
         'pydicom',  # DICOM metadata
-        # for >=0.9.0 -- https://github.com/datalad/datalad-neuroimaging/issues/67
-        # will eventually need >= 0.9.2 for https://github.com/bids-standard/pybids/pull/444
-        'pybids>=0.7.0,<0.9.0',  # BIDS metadata
+        # >= 0.9.2 for https://github.com/bids-standard/pybids/pull/444
+        'pybids>=0.9.2',  # BIDS metadata
         'nibabel',  # NIfTI metadata
         'pandas',  # bids2scidata export
     ],


### PR DESCRIPTION
Now that https://github.com/bids-standard/pybids/pull/444 was merged/released