### PR TITLE
BF: ignore broken derivatives

### DIFF
--- a/datalad_neuroimaging/extractors/bids.py
+++ b/datalad_neuroimaging/extractors/bids.py
@@ -69,7 +69,19 @@ class MetadataExtractor(BaseMetadataExtractor):
 
     def get_metadata(self, dataset, content):
         derivative_exist = exists(opj(self.ds.path, 'derivatives'))
-        bids = BIDSLayout(self.ds.path, derivatives=derivative_exist)
+        try:
+            bids = BIDSLayout(self.ds.path, derivatives=derivative_exist)
+        except ValueError as exc:
+            if 'BIDS-derivatives dataset must have' in str(exc):
+                lgr.warning(
+                    "Althought derivatives/ is present, that subdataset is not "
+                    "a compliant BIDS Derivatives dataset and will be ignored: "
+                    "%s",
+                    exc_str(exc)
+                )
+                bids = BIDSLayout(self.ds.path, derivatives=False)
+            else:
+                raise
 
         dsmeta = self._get_dsmeta(bids)
 

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,8 @@ setup(
         'datalad>=0.11',
         #'datalad-webapp',
         'pydicom',  # DICOM metadata
-        # for >=0.9.0 -- https://github.com/datalad/datalad-neuroimaging/issues/67
-        # will eventually need >= 0.9.2 for https://github.com/bids-standard/pybids/pull/444
-        'pybids>=0.7.0,<0.9.0',  # BIDS metadata
+        # >= 0.9.2 for https://github.com/bids-standard/pybids/pull/444
+        'pybids>=0.9.2',  # BIDS metadata
         'nibabel',  # NIfTI metadata
         'pandas',  # bids2scidata export
     ],


### PR DESCRIPTION
I CPed #72 as well since otherwise couldn't install in a local venv for some reason.  Most likely testing would fail probably for the same GitPython 3.x regressions as in #72 .

With this PR we will just not read derivative(s) metadata if reading them fails. Relevant issue in pybids is https://github.com/bids-standard/pybids/issues/473 which would boil down to more targetted exceptions so in the future we would be able to avoid matching a str(exc).