### PR TITLE
MNT: bids2scidata: Use .iloc instead of deprecated .ix

### DIFF
--- a/datalad_neuroimaging/bids2scidata.py
+++ b/datalad_neuroimaging/bids2scidata.py
@@ -395,7 +395,7 @@ def _gather_protocol_parameters_from_df(df, protocols):
                     break
             # this is a protocol definition column,
             # make entry for each unique value
-            protos = df.ix[:, i].unique()
+            protos = df.iloc[:, i].unique()
         if col.startswith('Parameter Value['):
             params.add(col[16:-1])
 


### PR DESCRIPTION
This popped up in the "DeprecationWarning -> error" run from datalad/datalad#3618: https://travis-ci.org/datalad/datalad/jobs/576041485#L1241