### PR TITLE
MNT: nipype_workshop_dataset: Update save() call for DataLad 0.12

### DIFF
--- a/docs/examples/nipype_workshop_dataset.sh
+++ b/docs/examples/nipype_workshop_dataset.sh
@@ -200,7 +200,7 @@ datalad add --to-git --nosave dataset_description.json
 datalad aggregate-metadata --nosave -r
 # and finally save all accumulated changes from above commands
 # while also updating the topmost superdataset about this changes under 'workshops'
-datalad save -S -m "Added dataset description and aggregated meta-data" -r
+datalad save -d'^' -m "Added dataset description and aggregated meta-data" -r
 # go upstairs and aggregate meta-information across its direct datasets without recursing
 # (since might take awhile)
 cd ..


### PR DESCRIPTION
In 0.12.x, `datalad save` no longer accepts --super-datasets.  In a
blind to make the example compatible with the latest DataLad, use the
--dataset=^ shortcut instead.

Note that there are other spots in the example that should be updated
for the 0.12.x release (e.g., use of `datalad add`).  This is just a minimal
attempt to get it passing.

Re: https://github.com/datalad/datalad-neuroimaging/pull/74#issuecomment-580340491

---

Note: A test failure due to issue resolved by gh-74 is still expected.