### PR TITLE
Use python 3.8 for building docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"


### PR DESCRIPTION
Added a `.readthedocs.yaml` file to make readthedocs use Python 3.8 (instead of 3.7) when building documentation. On 3.7 (default) the build failed when trying to install the package dependencies due to version mismatch (pandas / numpy).

This should cause the docs to start building again. Fixes #98 
