### PR TITLE
RF: use pytest, remove restriction on datalad version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -184,9 +184,9 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-    # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_neuroimaging %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_neuroimaging ${DTS}
+  # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
+  - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_neuroimaging --pyargs %DTS%
+  - sh:  python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_neuroimaging --pyargs ${DTS}
 
 
 after_test:

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -52,4 +52,4 @@ jobs:
         echo "== mount >>"
         mount
         echo "<< mount =="
-        python -m nose -s -v --with-doctest --with-coverage --cover-package datalad_neuroimaging datalad_neuroimaging
+        python -m pytest -s -v --cov=datalad_neuroimaging --pyargs datalad_neuroimaging

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,10 @@
 # Ideas borrowed from scikit-learn's and PyMVPA Makefiles  -- thanks!
 
 PYTHON ?= python
-NOSETESTS ?= nosetests
 
 MODULE ?= datalad
 
-all: clean test
+all: clean
 
 clean:
 	$(PYTHON) setup.py clean
@@ -17,15 +16,6 @@ clean:
 bin:
 	mkdir -p $@
 	PYTHONPATH=bin:$(PYTHONPATH) python setup.py develop --install-dir $@
-
-test-code: bin
-	PATH=bin:$(PATH) PYTHONPATH=bin:$(PYTHONPATH) $(NOSETESTS) -s -v $(MODULE)
-
-test-coverage:
-	rm -rf coverage .coverage
-	$(NOSETESTS) -s -v --with-coverage $(MODULE)
-
-test: test-code
 
 
 trailing-spaces:

--- a/datalad_neuroimaging/__init__.py
+++ b/datalad_neuroimaging/__init__.py
@@ -23,4 +23,5 @@ command_suite = (
 )
 
 from . import _version
+
 __version__ = _version.get_versions()['version']

--- a/datalad_neuroimaging/__init__.py
+++ b/datalad_neuroimaging/__init__.py
@@ -22,8 +22,5 @@ command_suite = (
     ]
 )
 
-from datalad import setup_package
-from datalad import teardown_package
-
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/datalad_neuroimaging/conftest.py
+++ b/datalad_neuroimaging/conftest.py
@@ -1,0 +1,1 @@
+from datalad.conftest import setup_package

--- a/datalad_neuroimaging/conftest.py
+++ b/datalad_neuroimaging/conftest.py
@@ -1,1 +1,1 @@
-from datalad.conftest import setup_package
+from datalad.conftest import *

--- a/datalad_neuroimaging/extractors/tests/test_bids.py
+++ b/datalad_neuroimaging/extractors/tests/test_bids.py
@@ -8,20 +8,20 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test BIDS metadata extractor """
 import json
-
 from math import isnan
 from os.path import join as opj
+
 from datalad.api import Dataset
-
-from nose.tools import assert_equal
 from datalad.support.external_versions import external_versions
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import (
+    assert_equal,
+    assert_in,
+    known_failure_osx,
+    known_failure_windows,
+    skip_if_no_module,
+    with_tree,
+)
 
-
-from datalad.tests.utils import skip_if_no_module
 skip_if_no_module('bids')
 
 from datalad_neuroimaging.extractors.bids import MetadataExtractor

--- a/datalad_neuroimaging/extractors/tests/test_bids_dataset.py
+++ b/datalad_neuroimaging/extractors/tests/test_bids_dataset.py
@@ -12,20 +12,22 @@ from math import isnan
 from os.path import join as opj
 
 from datalad.api import Dataset
-
-from nose.tools import assert_equal
 from datalad.support.external_versions import external_versions
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import (
+    assert_equal,
+    assert_in,
+    known_failure_osx,
+    known_failure_windows,
+    skip_if_no_module,
+    with_tree,
+)
 
-
-from datalad.tests.utils import skip_if_no_module
 skip_if_no_module('bids')
 
-from datalad_neuroimaging.extractors.bids_dataset import BIDSmeta
 from unittest import TestCase
+
+from datalad_neuroimaging.extractors.bids_dataset import BIDSmeta
+
 TestCase.maxDiff = None
 
 bids_template = {

--- a/datalad_neuroimaging/extractors/tests/test_dicom.py
+++ b/datalad_neuroimaging/extractors/tests/test_dicom.py
@@ -9,27 +9,35 @@
 """Test DICOM extractor"""
 
 from datalad.tests.utils_pytest import SkipTest
+
 try:
-    from datalad_neuroimaging.extractors.dicom import MetadataExtractor as DicomExtractor
+    from datalad_neuroimaging.extractors.dicom import \
+        MetadataExtractor as DicomExtractor
 except ImportError:
     raise SkipTest
 
-from shutil import copy
 import os.path as op
+from shutil import copy
+
 from datalad.api import Dataset
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import assert_status
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import eq_
-from datalad.tests.utils_pytest import assert_dict_equal
-from datalad.tests.utils_pytest import assert_in
-from datalad.tests.utils_pytest import assert_not_in
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
+from datalad.tests.utils_pytest import (
+    assert_dict_equal,
+    assert_in,
+    assert_not_in,
+    assert_result_count,
+    assert_status,
+    eq_,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    skip_if_adjusted_branch,
+    with_tempfile,
+)
+
 from . import datalad_extracts_annex_key
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @with_tempfile(mkdir=True)

--- a/datalad_neuroimaging/extractors/tests/test_dicom.py
+++ b/datalad_neuroimaging/extractors/tests/test_dicom.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test DICOM extractor"""
 
-from datalad.tests.utils import SkipTest
+from datalad.tests.utils_pytest import SkipTest
 try:
     from datalad_neuroimaging.extractors.dicom import MetadataExtractor as DicomExtractor
 except ImportError:
@@ -17,16 +17,16 @@ except ImportError:
 from shutil import copy
 import os.path as op
 from datalad.api import Dataset
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import eq_
-from datalad.tests.utils import assert_dict_equal
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import assert_status
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import eq_
+from datalad.tests.utils_pytest import assert_dict_equal
+from datalad.tests.utils_pytest import assert_in
+from datalad.tests.utils_pytest import assert_not_in
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 from . import datalad_extracts_annex_key
 
 

--- a/datalad_neuroimaging/extractors/tests/test_nidm.py
+++ b/datalad_neuroimaging/extractors/tests/test_nidm.py
@@ -12,12 +12,12 @@ from shutil import copy
 from os.path import dirname
 from os.path import join as opj
 from datalad.api import Dataset
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import assert_status
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 from . import datalad_extracts_annex_key
 
 

--- a/datalad_neuroimaging/extractors/tests/test_nidm.py
+++ b/datalad_neuroimaging/extractors/tests/test_nidm.py
@@ -8,19 +8,25 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test NIDM extractor"""
 
-from shutil import copy
 from os.path import dirname
 from os.path import join as opj
+from shutil import copy
+
 from datalad.api import Dataset
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import assert_status
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
+from datalad.tests.utils_pytest import (
+    assert_result_count,
+    assert_status,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    skip_if_adjusted_branch,
+    with_tempfile,
+)
+
 from . import datalad_extracts_annex_key
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @with_tempfile(mkdir=True)

--- a/datalad_neuroimaging/extractors/tests/test_nifti1.py
+++ b/datalad_neuroimaging/extractors/tests/test_nifti1.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test NIfTI extractor"""
 
-from datalad.tests.utils import SkipTest
+from datalad.tests.utils_pytest import SkipTest
 try:
     import nibabel
 except ImportError:
@@ -18,14 +18,14 @@ from shutil import copy
 from os.path import dirname
 from os.path import join as opj
 from datalad.api import Dataset
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import eq_
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import assert_status
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import eq_
+from datalad.tests.utils_pytest import assert_in
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 
 
 target = {

--- a/datalad_neuroimaging/extractors/tests/test_nifti1.py
+++ b/datalad_neuroimaging/extractors/tests/test_nifti1.py
@@ -9,24 +9,28 @@
 """Test NIfTI extractor"""
 
 from datalad.tests.utils_pytest import SkipTest
+
 try:
     import nibabel
 except ImportError:
     raise SkipTest
 
-from shutil import copy
 from os.path import dirname
 from os.path import join as opj
-from datalad.api import Dataset
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import assert_status
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import eq_
-from datalad.tests.utils_pytest import assert_in
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
+from shutil import copy
 
+from datalad.api import Dataset
+from datalad.tests.utils_pytest import (
+    assert_in,
+    assert_result_count,
+    assert_status,
+    eq_,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    skip_if_adjusted_branch,
+    with_tempfile,
+)
 
 target = {
     "description": "FSL5.0",
@@ -56,6 +60,7 @@ target = {
 }
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @with_tempfile(mkdir=True)

--- a/datalad_neuroimaging/resources/procedures/cfg_bids.py
+++ b/datalad_neuroimaging/resources/procedures/cfg_bids.py
@@ -3,6 +3,7 @@
 """
 
 import sys
+
 from datalad.distribution.dataset import require_dataset
 from datalad.support import path as op
 

--- a/datalad_neuroimaging/resources/procedures/cfg_bids.py
+++ b/datalad_neuroimaging/resources/procedures/cfg_bids.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Procedure to apply a sensible BIDS default setup to a dataset
 """
 

--- a/datalad_neuroimaging/tests/test_aggregation.py
+++ b/datalad_neuroimaging/tests/test_aggregation.py
@@ -12,11 +12,11 @@
 
 from datalad.distribution.dataset import Dataset
 
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import assert_dict_equal
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import with_tree
+from datalad.tests.utils_pytest import assert_dict_equal
+from datalad.tests.utils_pytest import assert_not_in
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 from ..extractors.tests.test_bids import bids_template
 
 

--- a/datalad_neuroimaging/tests/test_aggregation.py
+++ b/datalad_neuroimaging/tests/test_aggregation.py
@@ -11,15 +11,19 @@
 
 
 from datalad.distribution.dataset import Dataset
+from datalad.tests.utils_pytest import (
+    assert_dict_equal,
+    assert_not_in,
+    known_failure_osx,
+    known_failure_windows,
+    skip_if_adjusted_branch,
+    with_tree,
+)
 
-from datalad.tests.utils_pytest import with_tree
-from datalad.tests.utils_pytest import assert_dict_equal
-from datalad.tests.utils_pytest import assert_not_in
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
 from ..extractors.tests.test_bids import bids_template
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @with_tree(tree=bids_template)

--- a/datalad_neuroimaging/tests/test_bids2scidata.py
+++ b/datalad_neuroimaging/tests/test_bids2scidata.py
@@ -18,21 +18,21 @@ from datalad.api import install
 from datalad.utils import chpwd
 from datalad_neuroimaging.tests.utils import get_bids_dataset
 
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import eq_
-from datalad.tests.utils import assert_true, assert_not_equal, assert_raises, \
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import with_tree
+from datalad.tests.utils_pytest import eq_
+from datalad.tests.utils_pytest import assert_true, assert_not_equal, assert_raises, \
     assert_false, assert_equal
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import assert_status
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import assert_in
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 
 from datalad.support.exceptions import IncompleteResultsError
 
-from datalad.tests.utils import skip_if_no_module
+from datalad.tests.utils_pytest import skip_if_no_module
 skip_if_no_module('pandas')
 
 

--- a/datalad_neuroimaging/tests/test_bids2scidata.py
+++ b/datalad_neuroimaging/tests/test_bids2scidata.py
@@ -13,26 +13,33 @@ import os.path as op
 from os import listdir
 from os.path import join as opj
 
-from datalad.api import Dataset
-from datalad.api import install
+from datalad.api import (
+    Dataset,
+    install,
+)
+from datalad.support.exceptions import IncompleteResultsError
+from datalad.tests.utils_pytest import (
+    assert_equal,
+    assert_false,
+    assert_in,
+    assert_not_equal,
+    assert_raises,
+    assert_result_count,
+    assert_status,
+    assert_true,
+    eq_,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    skip_if_adjusted_branch,
+    skip_if_no_module,
+    with_tempfile,
+    with_tree,
+)
 from datalad.utils import chpwd
+
 from datalad_neuroimaging.tests.utils import get_bids_dataset
 
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import with_tree
-from datalad.tests.utils_pytest import eq_
-from datalad.tests.utils_pytest import assert_true, assert_not_equal, assert_raises, \
-    assert_false, assert_equal
-from datalad.tests.utils_pytest import assert_status
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import assert_in
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
-
-from datalad.support.exceptions import IncompleteResultsError
-
-from datalad.tests.utils_pytest import skip_if_no_module
 skip_if_no_module('pandas')
 
 
@@ -97,6 +104,7 @@ def test_noop(path=None, outdir=None):
         )
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @with_tree(_bids_template)
@@ -161,6 +169,7 @@ Sample Name\tProtocol REF\tParameter Value[modality]\tAssay Name\tRaw Data File\
 # new aggregated metadata in any of them
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @with_tempfile(mkdir=True)

--- a/datalad_neuroimaging/tests/test_dicomconv.py
+++ b/datalad_neuroimaging/tests/test_dicomconv.py
@@ -13,18 +13,21 @@
 from os.path import join as opj
 
 from datalad.api import Dataset
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import eq_
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
-from datalad.tests.utils_pytest import skip_if_adjusted_branch
-
+from datalad.tests.utils_pytest import (
+    assert_result_count,
+    eq_,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    skip_if_adjusted_branch,
+    with_tempfile,
+)
 
 import datalad_neuroimaging
-from datalad_neuroimaging.tests.utils import get_dicom_dataset
-from datalad_neuroimaging.tests.utils import get_bids_dataset
+from datalad_neuroimaging.tests.utils import (
+    get_bids_dataset,
+    get_dicom_dataset,
+)
 
 
 @known_failure_windows

--- a/datalad_neuroimaging/tests/test_dicomconv.py
+++ b/datalad_neuroimaging/tests/test_dicomconv.py
@@ -13,12 +13,12 @@
 from os.path import join as opj
 
 from datalad.api import Dataset
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import eq_
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import eq_
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 
 
 import datalad_neuroimaging

--- a/datalad_neuroimaging/tests/test_dicomconv.py
+++ b/datalad_neuroimaging/tests/test_dicomconv.py
@@ -19,6 +19,7 @@ from datalad.tests.utils_pytest import with_tempfile
 from datalad.tests.utils_pytest import eq_
 from datalad.tests.utils_pytest import known_failure_osx
 from datalad.tests.utils_pytest import known_failure_windows
+from datalad.tests.utils_pytest import skip_if_adjusted_branch
 
 
 import datalad_neuroimaging
@@ -40,6 +41,7 @@ def test_dicom_metadata_aggregation(path=None):
     assert_result_count(res, 1, path=opj(ds.path, 'acq100'))
 
 
+@skip_if_adjusted_branch
 @known_failure_windows
 @known_failure_osx
 def test_validate_bids_fixture():

--- a/datalad_neuroimaging/tests/test_procedure.py
+++ b/datalad_neuroimaging/tests/test_procedure.py
@@ -12,7 +12,7 @@ import datalad.interface.run_procedure
 @known_failure_windows
 @known_failure_osx
 @with_tempfile
-def test_bids_procedure(path):
+def test_bids_procedure(path=None):
     ds = Dataset(path).create()
     ds.run_procedure(['cfg_bids'])
     ds.config.reload()

--- a/datalad_neuroimaging/tests/test_procedure.py
+++ b/datalad_neuroimaging/tests/test_procedure.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     with_tempfile,
     eq_,
     ok_clean_git,

--- a/datalad_neuroimaging/tests/test_procedure.py
+++ b/datalad_neuroimaging/tests/test_procedure.py
@@ -1,12 +1,12 @@
-from datalad.tests.utils_pytest import (
-    with_tempfile,
-    eq_,
-    ok_clean_git,
-    known_failure_osx,
-    known_failure_windows
-)
-from datalad.distribution.dataset import Dataset
 import datalad.interface.run_procedure
+from datalad.distribution.dataset import Dataset
+from datalad.tests.utils_pytest import (
+    eq_,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    with_tempfile,
+)
 
 
 @known_failure_windows

--- a/datalad_neuroimaging/tests/test_register.py
+++ b/datalad_neuroimaging/tests/test_register.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import assert_result_count
+from datalad.tests.utils_pytest import assert_result_count
 
 
 def test_register():

--- a/datalad_neuroimaging/tests/test_search.py
+++ b/datalad_neuroimaging/tests/test_search.py
@@ -41,7 +41,7 @@ except (ImportError, SkipTest):
 @known_failure_windows
 @known_failure_osx
 @with_tempfile
-def test_our_metadataset_search(tdir):
+def test_our_metadataset_search(tdir=None):
     # TODO renable when a dataset with new aggregated metadata is
     # available at some public location
     raise SkipTest

--- a/datalad_neuroimaging/tests/test_search.py
+++ b/datalad_neuroimaging/tests/test_search.py
@@ -16,16 +16,16 @@ from os import makedirs
 from os.path import join as opj
 from os.path import dirname
 from datalad.utils import swallow_outputs
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_equal
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import SkipTest
-from datalad.tests.utils import skip_if
-from datalad.tests.utils import known_failure_osx
-from datalad.tests.utils import known_failure_windows
+from datalad.tests.utils_pytest import assert_in
+from datalad.tests.utils_pytest import assert_equal
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import with_tree
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import SkipTest
+from datalad.tests.utils_pytest import skip_if
+from datalad.tests.utils_pytest import known_failure_osx
+from datalad.tests.utils_pytest import known_failure_windows
 from datalad.support.external_versions import external_versions
 
 from datalad.api import Dataset

--- a/datalad_neuroimaging/tests/test_search.py
+++ b/datalad_neuroimaging/tests/test_search.py
@@ -9,28 +9,33 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Some additional tests for search command"""
 import os
-
 from difflib import unified_diff
-from shutil import copy
 from os import makedirs
-from os.path import join as opj
 from os.path import dirname
-from datalad.utils import swallow_outputs
-from datalad.tests.utils_pytest import assert_in
-from datalad.tests.utils_pytest import assert_equal
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import with_tree
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import SkipTest
-from datalad.tests.utils_pytest import skip_if
-from datalad.tests.utils_pytest import known_failure_osx
-from datalad.tests.utils_pytest import known_failure_windows
-from datalad.support.external_versions import external_versions
+from os.path import join as opj
+from shutil import copy
 
-from datalad.api import Dataset
-from datalad.api import search
+from datalad.api import (
+    Dataset,
+    search,
+)
 from datalad.metadata import search as search_mod
+from datalad.support.external_versions import external_versions
+from datalad.tests.utils_pytest import (
+    SkipTest,
+    assert_equal,
+    assert_in,
+    assert_result_count,
+    known_failure_osx,
+    known_failure_windows,
+    ok_clean_git,
+    skip_if,
+    skip_if_adjusted_branch,
+    with_tempfile,
+    with_tree,
+)
+from datalad.utils import swallow_outputs
+
 try:
     from datalad_neuroimaging.extractors.tests.test_bids import bids_template
 except (ImportError, SkipTest):
@@ -61,9 +66,9 @@ def test_our_metadataset_search(tdir=None):
         path=opj(ds.path, 'crcns', 'pfc-2'))
 
     # there is a problem with argparse not decoding into utf8 in PY2
-    from datalad.cmdline.tests.test_main import run_main
     # TODO: make it into an independent lean test
     from datalad.cmd import Runner
+    from datalad.cmdline.tests.test_main import run_main
     out, err = Runner(cwd=ds.path)('datalad search Buzsáki')
     assert_in('crcns/pfc-2 ', out)  # has it in description
     # and then another aspect: this entry it among multiple authors, need to
@@ -71,6 +76,7 @@ def test_our_metadataset_search(tdir=None):
     assert_in('crcns/hc-1 ', out)
 
 
+@skip_if_adjusted_branch  # fails on crippled fs test
 @known_failure_windows
 @known_failure_osx
 @skip_if(not bids_template, "No bids_template (probably no pybids installed)")

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -4,8 +4,8 @@ import os.path as op
 from datalad.api import Dataset
 from datalad.api import export_archive
 from datalad.coreapi import install
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import SkipTest
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import SkipTest
 from datalad.interface.common_cfg import dirs as appdirs
 
 import datalad_neuroimaging

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -1,12 +1,21 @@
-from os.path import dirname, normpath, join as opj, pardir
 import os.path as op
+from os.path import dirname
+from os.path import join as opj
+from os.path import (
+    normpath,
+    pardir,
+)
 
-from datalad.api import Dataset
-from datalad.api import export_archive
+from datalad.api import (
+    Dataset,
+    export_archive,
+)
 from datalad.coreapi import install
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import SkipTest
 from datalad.interface.common_cfg import dirs as appdirs
+from datalad.tests.utils_pytest import (
+    SkipTest,
+    ok_clean_git,
+)
 
 import datalad_neuroimaging
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,4 @@
-# requirements for a development environment
-nose
-coverage
-sphinx
-sphinx_rtd_theme
-pytest
-pytest-cov
+# Theoretically we don't want -e here but ATM pip would puke if just .[full] is provided
+# Since we use requirements.txt ATM only for development IMHO it is ok but
+# we need to figure out/complaint to pip folks
+-e .[devel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 zip_safe = False
 python_requires = >= 3.7
 install_requires =
-    datalad == 0.16.7
+    datalad >= 0.16.7
     pydicom  # DICOM metadata
     pybids >= 0.15.1  # BIDS metadata
     nibabel  # NIfTI metadata
@@ -28,8 +28,8 @@ include_package_data = True
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
-    nose
-    coverage
+    pytest
+    pytest-cov
     pypandoc
     sphinx >= 1.6.2
     sphinx-rtd-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ devel =
     pytest
     pytest-cov
     pypandoc
+    datalad >= 0.17.0
     sphinx >= 1.6.2
     sphinx-rtd-theme
     heudiconv


### PR DESCRIPTION
for the failing test -- we might be doomed to skip it for now, but we cannot really delay that long
- skipped also most of the tests on crippled fs. Not surprisingly they all are already marked as known to fail on windows
- in those files which touched, did isort to bring some consistency