### PR TITLE
Adapt to the move of metadata-code from `datalad` to `datalad-deprecated`

### DIFF
--- a/datalad_neuroimaging/bids2scidata.py
+++ b/datalad_neuroimaging/bids2scidata.py
@@ -29,7 +29,6 @@ from os.path import split as psplit
 import datalad
 import datalad_neuroimaging
 from datalad import cfg
-from datalad.coreapi import metadata
 from datalad.distribution.dataset import require_dataset
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
@@ -39,9 +38,14 @@ from datalad.interface.utils import eval_results
 from datalad.distribution.dataset import EnsureDataset
 from datalad.support.constraints import EnsureNone
 from datalad.utils import assure_list
+from datalad_deprecated.metadata.metadata import Metadata
 from six.moves.urllib.parse import urlsplit
 from six.moves.urllib.parse import urlunsplit
 from posixpath import split as posixsplit
+
+
+# Adapt to metadata code move from datalad-core to datalad-deprecated
+metadata = Metadata.__call__
 
 
 try:

--- a/datalad_neuroimaging/extractors/bids.py
+++ b/datalad_neuroimaging/extractors/bids.py
@@ -20,13 +20,12 @@ from io import open
 from os.path import join as opj
 from os.path import exists
 from os.path import curdir
+from datalad import cfg
 from datalad.dochelpers import exc_str
-from datalad.metadata.extractors.base import BaseMetadataExtractor
-from datalad.metadata.definitions import vocabulary_id
 from datalad.utils import assure_unicode
 from datalad.support.external_versions import external_versions
-
-from datalad import cfg
+from datalad_deprecated.metadata.extractors.base import BaseMetadataExtractor
+from datalad_deprecated.metadata.definitions import vocabulary_id
 
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.bids')

--- a/datalad_neuroimaging/extractors/bids_dataset.py
+++ b/datalad_neuroimaging/extractors/bids_dataset.py
@@ -13,13 +13,14 @@ from uuid import UUID
 
 from bids import BIDSLayout
 from datalad.log import log_progress
-from datalad.metadata.definitions import vocabulary_id
 from datalad.utils import ensure_unicode
 from datalad_metalad.extractors.base import (
     DataOutputCategory,
     DatasetMetadataExtractor,
     ExtractorResult,
 )
+from datalad_deprecated.metadata.definitions import vocabulary_id
+
 
 lgr = logging.getLogger("datalad.metadata.extractors.bids_dataset")
 

--- a/datalad_neuroimaging/extractors/dicom.py
+++ b/datalad_neuroimaging/extractors/dicom.py
@@ -31,8 +31,9 @@ except ImportError:
     from collections import MutableSequence
 
 from distutils.version import LooseVersion
-from datalad.metadata.definitions import vocabulary_id
-from datalad.metadata.extractors.base import BaseMetadataExtractor
+from datalad_deprecated.metadata.definitions import vocabulary_id
+from datalad_deprecated.metadata.extractors.base import BaseMetadataExtractor
+
 
 # pydicom 2.0.0 renamed PersonName3 to PersonName:
 PersonName = dcm.valuerep.PersonName3 \

--- a/datalad_neuroimaging/extractors/nidm.py
+++ b/datalad_neuroimaging/extractors/nidm.py
@@ -14,8 +14,8 @@
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.nidm')
 
-from datalad.metadata.definitions import vocabulary_id
-from datalad.metadata.extractors.base import BaseMetadataExtractor
+from datalad_deprecated.metadata.definitions import vocabulary_id
+from datalad_deprecated.metadata.extractors.base import BaseMetadataExtractor
 
 
 class MetadataExtractor(BaseMetadataExtractor):

--- a/datalad_neuroimaging/extractors/nifti1.py
+++ b/datalad_neuroimaging/extractors/nifti1.py
@@ -16,9 +16,9 @@ from datalad.log import log_progress
 from math import isnan
 import nibabel
 import numpy as np
-from datalad.metadata.definitions import vocabulary_id
-from datalad.metadata.extractors.base import BaseMetadataExtractor
 from datalad.dochelpers import exc_str
+from datalad_deprecated.metadata.definitions import vocabulary_id
+from datalad_deprecated.metadata.extractors.base import BaseMetadataExtractor
 
 
 vocabulary = {

--- a/datalad_neuroimaging/tests/test_aggregation.py
+++ b/datalad_neuroimaging/tests/test_aggregation.py
@@ -19,8 +19,12 @@ from datalad.tests.utils_pytest import (
     skip_if_adjusted_branch,
     with_tree,
 )
+from datalad_deprecated.metadata.metadata import Metadata
 
 from ..extractors.tests.test_bids import bids_template
+
+
+metadata = Metadata.__call__
 
 
 @skip_if_adjusted_branch  # fails on crippled fs test
@@ -35,8 +39,9 @@ def test_nested_metadata(path=None):
     # content metadata. On the dataset-level this should automatically
     # yield a sequence of participant info dicts, without any further action
     # or BIDS-specific configuration
-    meta = ds.metadata(
-        '.', reporton='datasets', return_type='item-or-list')['metadata']
+    meta = metadata(
+        '.', dataset=ds, reporton='datasets', return_type='item-or-list'
+    )['metadata']
     for i in zip(
             sorted(
                 meta['datalad_unique_content_properties']['bids']['subject'],

--- a/datalad_neuroimaging/tests/test_dicomconv.py
+++ b/datalad_neuroimaging/tests/test_dicomconv.py
@@ -24,10 +24,16 @@ from datalad.tests.utils_pytest import (
 )
 
 import datalad_neuroimaging
+from datalad_deprecated.metadata.aggregate import AggregateMetaData
+from datalad_deprecated.metadata.metadata import Metadata
 from datalad_neuroimaging.tests.utils import (
     get_bids_dataset,
     get_dicom_dataset,
 )
+
+
+aggregate_metadata = AggregateMetaData.__call__
+metadata = Metadata.__call__
 
 
 @known_failure_windows
@@ -38,8 +44,8 @@ def test_dicom_metadata_aggregation(path=None):
 
     ds = Dataset.create(path)
     ds.install(source=dicoms, path='acq100')
-    ds.aggregate_metadata(recursive=True)
-    res = ds.metadata(get_aggregates=True)
+    aggregate_metadata(dataset=ds, recursive=True)
+    res = metadata(dataset=ds, get_aggregates=True)
     assert_result_count(res, 2)
     assert_result_count(res, 1, path=opj(ds.path, 'acq100'))
 

--- a/datalad_neuroimaging/tests/test_procedure.py
+++ b/datalad_neuroimaging/tests/test_procedure.py
@@ -26,4 +26,3 @@ def test_bids_procedure(path=None):
     ds.run_procedure(['cfg_bids'])
     eq_(origsha, ds.repo.get_hexsha())
     ok_clean_git(ds.path)
-

--- a/datalad_neuroimaging/tests/utils.py
+++ b/datalad_neuroimaging/tests/utils.py
@@ -6,6 +6,7 @@ from os.path import (
     pardir,
 )
 
+import datalad_neuroimaging
 from datalad.api import (
     Dataset,
     export_archive,
@@ -16,8 +17,12 @@ from datalad.tests.utils_pytest import (
     SkipTest,
     ok_clean_git,
 )
+from datalad_deprecated.metadata.aggregate import AggregateMetaData
+from datalad_deprecated.metadata.metadata import Metadata
 
-import datalad_neuroimaging
+
+aggregate_metadata = AggregateMetaData.__call__
+metadata = Metadata.__call__
 
 
 def get_sourcerepo():
@@ -70,11 +75,11 @@ def get_bids_dataset():
     # dicom dataset is preconfigured for metadata extraction
     # XXX this is the slowest step of the entire procedure
     # reading 5k dicoms of the functional data
-    bids_ds.aggregate_metadata(recursive=True)
+    aggregate_metadata(dataset=bids_ds, recursive=True)
     # pull subject ID from metadata
-    res = bids_ds.metadata(
-        funcdicom_ds.path, reporton='datasets', return_type='item-or-list',
-        result_renderer='disabled')
+    res = metadata(
+        funcdicom_ds.path, dataset=bids_ds, reporton='datasets',
+        return_type='item-or-list', result_renderer='disabled')
     subj_id = res['metadata']['dicom']['Series'][0]['PatientID']
     # prepare for incoming BIDS metadata that we will want to keep in
     # Git -- templates would be awesome!
@@ -136,7 +141,7 @@ def get_bids_dataset():
         check=False)
     # no need for recursion, we already have the dicom dataset's
     # stuff on record
-    bids_ds.aggregate_metadata(recursive=False, incremental=True)
+    aggregate_metadata(dataset=bids_ds, recursive=False, incremental=True)
     ok_clean_git(bids_ds.path)
     return bids_ds
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ zip_safe = False
 python_requires = >= 3.7
 install_requires =
     datalad >= 0.16.7
-    datalad_deprecated
+    datalad_deprecated >= 0.2.5
     pydicom  # DICOM metadata
     pybids >= 0.15.1  # BIDS metadata
     nibabel  # NIfTI metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ zip_safe = False
 python_requires = >= 3.7
 install_requires =
     datalad >= 0.16.7
+    datalad_deprecated
     pydicom  # DICOM metadata
     pybids >= 0.15.1  # BIDS metadata
     nibabel  # NIfTI metadata


### PR DESCRIPTION
This PR adapts the parts of `datalad_neuroimaging` that used the old metadata code, i.e. the code contained in `datalad.metadata`, to the new location of this code, i.e. `datalad_deprecated.metadata`.
