### PR TITLE
[ENH] do not annex typical top files in BIDS datasets

### DIFF
--- a/datalad_neuroimaging/resources/procedures/cfg_bids.py
+++ b/datalad_neuroimaging/resources/procedures/cfg_bids.py
@@ -16,9 +16,11 @@ ds = require_dataset(
 # will get its own .gitattributes entry to keep it out of the annex
 # give relative path to dataset root (use platform notation)
 force_in_git = [
-    'README',
+    'README*',
     'CHANGES',
+    'LICENSE',
     'dataset_description.json',
+    '.bids-validator-config.json',
     '.bidsignore',
     'code/**',
     # to not put participants or scan info into Git, might contain sensitive


### PR DESCRIPTION
## context

Mentioned on the matrix datalad channel.

BIDS supports:

- `README`
- `README.txt`
- `README.rst`
- `README.md`

https://bids-specification.readthedocs.io/en/latest/modality-agnostic-files.html#readme

## AIM

This PR aims to make bids config reflect that.

## Additional changes

Do not annex license file

- `LICENSE`

https://bids-specification.readthedocs.io/en/latest/modality-agnostic-files.html#license

Do not annex the bids-validator config

- `.bids-validator-config.json`

https://github.com/bids-standard/bids-validator#configuration

Even though users may name this file differently, it may make sense to support the default name.