### PR TITLE
Update docs and CI build configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,7 +76,7 @@ environment:
     # MacOS core tests
     - ID: MacP38
       DTS: datalad_neuroimaging
-      APPVEYOR_BUILD_WORKER_IMAGE: macOS
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,14 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: "ubuntu-22.04"
   tools:
     python: "3.8"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
Switched macOS appveyor build from "macOS" to "macos-monterey" to avoid stalling on older versions (following https://github.com/datalad/datalad-extension-template/pull/50). Fixes #116 

Added instruction to install this package before building docs to readthedocs config. The config is needed to specify Python version, and apparently now also needs to include dependency specification.  Fixes #117