### PR TITLE
Add extra requirements to RtD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,3 +18,5 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - devel-docs


### PR DESCRIPTION
Read the Docs projects created before Oct 20, 2020 (like this one) use Sphinx 1.8.x. New projects use the latest version ([docs](https://docs.readthedocs.io/en/stable/build-default-versions.html)). Using default build requirements seems to have caused complex dependency conflicts. The only way to override these defaults seems to be through the .readthdocs.yaml config file.

The change introduced here will tell RtD to perform `pip install -e. [devel-docs]`. This relies on the fact that our setup.cfg already defines a loosely pinned (>=) sphinx dependency. Alternatively, we could introduce a dedicated requirements file for documentation, and use "requirements" key in python.install section ([docs](https://docs.readthedocs.io/en/stable/config-file/v2.html)). But here we rely on what's already defined.

Closes #117 (see issue comments for details and alternatives).