### PR TITLE
Set up releasing workflows

### DIFF
--- a/.datalad-release-action.yaml
+++ b/.datalad-release-action.yaml
@@ -1,0 +1,29 @@
+fragment-directory: changelog.d
+
+categories:
+  - name: 💥 Breaking Changes
+    bump: major
+    label: semver-major
+  - name: 🚀 Enhancements and New Features
+    bump: minor
+    label: semver-minor
+  - name: 🐛 Bug Fixes
+    label: semver-patch
+  - name: 🔩 Dependencies
+    label: semver-dependencies
+  - name: 📝 Documentation
+    label: semver-documentation
+  - name: 🏠 Internal
+    label: semver-internal
+  - name: 🏎 Performance
+    label: semver-performance
+  - name: 🧪 Tests
+    label: semver-tests
+
+extra-labels:
+  - name: release
+    color: 007f70
+    description: Create a release when this PR is merged
+  - name: CHANGELOG-missing
+    color: 5b0406
+    description: PR does not contain a changelog item yet

--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -1,0 +1,34 @@
+name: Add changelog.d snippet
+
+on:
+  # This action should be run in workflows triggered by `pull_request_target`
+  # (not by regular `pull_request`!)
+  pull_request_target:
+    # Run whenever the PR is pushed to, receives a label, or is created with
+    # one or more labels:
+    types: [synchronize, labeled]
+
+# Prevent the workflow from running multiple jobs at once when a PR is created
+# with multiple labels:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label }}
+  cancel-in-progress: true
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    # Only run on PRs that have the "CHANGELOG-missing" label:
+    if: contains(github.event.pull_request.labels.*.name, 'CHANGELOG-missing')
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.RELEASER_GITHUB_TOKEN }}
+
+      - name: Add changelog snippet
+        uses: datalad/release-action/add-changelog-snippet@v1
+        with:
+          token: ${{ secrets.RELEASER_GITHUB_TOKEN }}
+          rm-labels: CHANGELOG-missing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Auto-release on PR merge
+
+on:
+  # This action should be run in workflows triggered by `pull_request_target`
+  # (not by regular `pull_request`!)
+  pull_request_target:
+    branches:
+      # Create a release whenever a PR is merged into one of these branches:
+      - master
+    types:
+      - closed
+  # Allow manually triggering a release via a "Run workflow" button on the
+  # workflow's page:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only run for manual runs or merged PRs with the "release" label:
+    if: >
+      github.event_name == 'workflow_dispatch'
+         || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASER_GITHUB_TOKEN }}
+          # Check out all history so that the previous release tag can be
+          # found:
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: datalad/release-action/release@v1
+        with:
+          token: ${{ secrets.RELEASER_GITHUB_TOKEN }}
+          pypi-token: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,3 @@
-     ____            _             _                   _ 
-    |  _ \    __ _  | |_    __ _  | |       __ _    __| |
-    | | | |  / _` | | __|  / _` | | |      / _` |  / _` |
-    | |_| | | (_| | | |_  | (_| | | |___  | (_| | | (_| |
-    |____/   \__,_|  \__|  \__,_| |_____|  \__,_|  \__,_|
-                                               Neuroimaging
-
-This is a high level and scarce summary of the changes between releases.  We
-would recommend to consult log of the [DataLad git
-repository](http://github.com/datalad/datalad-neuroimaging) for more details.
-
 ## 0.3.4 (Oct 24, 2023) -- Make BIDS great again
 
 - BIDS metadata extractor(s): do not require `participants.tsv` file to be present

--- a/changelog.d/pr-130.md
+++ b/changelog.d/pr-130.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Set up releasing workflows.  Fixes [#127](https://github.com/datalad/datalad-neuroimaging/issues/127) via [PR #130](https://github.com/datalad/datalad-neuroimaging/pull/130) (by [@jwodder](https://github.com/jwodder))

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,8 @@
+[scriv]
+fragment_directory = changelog.d
+entry_title_template = file: templates/entry_title.md.j2
+new_fragment_template = file: templates/new_fragment.md.j2
+format = md
+# The categories must align with the category names in
+# .datalad-release-action.yaml
+categories = 💥 Breaking Changes, 🚀 Enhancements and New Features, 🐛 Bug Fixes, 🔩 Dependencies, 📝 Documentation, 🏠 Internal, 🏎 Performance, 🧪 Tests

--- a/changelog.d/templates/entry_title.md.j2
+++ b/changelog.d/templates/entry_title.md.j2
@@ -1,0 +1,1 @@
+{{ version if version else "VERSION" }} ({{ date.strftime('%Y-%m-%d') }})

--- a/changelog.d/templates/new_fragment.md.j2
+++ b/changelog.d/templates/new_fragment.md.j2
@@ -1,0 +1,11 @@
+<!-- Uncomment the section that is right (remove the HTML comment wrapper).-->
+{% for cat in config.categories -%}
+<!--
+### {{ cat }}
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-neuroimaging/issues/XXX) via
+  [PR #YYY](https://github.com/datalad/datalad-neuroimaging/pull/YYY)
+  (by [@GITHUBHANDLE](https://github.com/GITHUBHANDLE))
+-->
+{% endfor -%}


### PR DESCRIPTION
Closes #127.

To do before merging:

- [x] Create labels used by the release action
- [x] Add a `RELEASER_GITHUB_TOKEN` secret to this repository containing the GitHub access token to use when pushing changelog snippets, pushing changelog updates, commenting on released PRs, etc.
- [x] Add a `PYPI_TOKEN` secret to this repository containing a PyPI token for uploading packages for this project