### PR TITLE
Add codespell config and workflow, and use it to typos found throughout the codebase

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -184,7 +184,7 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-  # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
+  # run test selection (--traverse-namespace needed from Python 3.8 onwards)
   - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_neuroimaging --pyargs %DTS%
   - sh:  python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_neuroimaging --pyargs ${DTS}
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# simple makefile to simplify repetetive build env management tasks under posix
+# simple makefile to simplify repetitive build env management tasks under posix
 # Ideas borrowed from scikit-learn's and PyMVPA Makefiles  -- thanks!
 
 PYTHON ?= python

--- a/_datalad_buildsupport/formatters.py
+++ b/_datalad_buildsupport/formatters.py
@@ -75,7 +75,7 @@ class ManPageFormatter(argparse.HelpFormatter):
 
     def _mk_name(self, prog, desc):
         """
-        this method is in consitent with others ... it relies on
+        this method is in consistent with others ... it relies on
         distribution
         """
         desc = desc.splitlines()[0] if desc else 'it is in the name'

--- a/changelog.d/pr-131.md
+++ b/changelog.d/pr-131.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Add codespell config and workflow, and use it to typos found throughout the codebase.  [PR #131](https://github.com/datalad/datalad-neuroimaging/pull/131) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad_neuroimaging/__init__.py
+++ b/datalad_neuroimaging/__init__.py
@@ -5,7 +5,7 @@ __docformat__ = 'restructuredtext'
 from .version import __version__
 
 # defines a datalad command suite
-# this symbold must be indentified as a setuptools entrypoint
+# this symbold must be identified as a setuptools entrypoint
 # to be found by datalad
 command_suite = (
     # description of the command suite, displayed in cmdline help

--- a/datalad_neuroimaging/bids2scidata.py
+++ b/datalad_neuroimaging/bids2scidata.py
@@ -85,7 +85,7 @@ ontology_map = {
 # (datalad_term, isatab_term)
 # if datalad term is None, it needs to come from somewhere else -> special case
 # if datalad term is '', it comes from the filename
-# case 1: the defintion for a term value comes from another metadata field
+# case 1: the definition for a term value comes from another metadata field
 # (datalad_term, isatab_term, datalad_valuedef
 # case 2: we take the value as-is and define a unit for it
 # (datalad_term, isatab_term, isatab_unitvalue, isatab_unitdef
@@ -300,7 +300,7 @@ def _get_assay_df(
     # main assays
     # we cannot use a dict to collect the data before going to
     # a data frame, because we will have multiple columns with
-    # the same name carrying the ontology info for preceeding
+    # the same name carrying the ontology info for preceding
     # columns
     # --> prefix with some index, create dataframe and rename
     # the column names in the dataframe with the prefix stripped

--- a/datalad_neuroimaging/extractors/nifti1.py
+++ b/datalad_neuroimaging/extractors/nifti1.py
@@ -40,8 +40,8 @@ vocabulary = {
 
 unit_map = {
     'meter': ('meter', 'uo:0000008'),
-    'millimeter': ('millimiter', 'uo:0000016'),
-    'mm': ('millimiter', 'uo:0000016'),
+    'millimeter': ('millimeter', 'uo:0000016'),
+    'mm': ('millimeter', 'uo:0000016'),
     'micron': ('micrometer', 'uo:0000017'),
     'second': ('second', 'uo:0000010'),
     'sec': ('second', 'uo:0000010'),

--- a/datalad_neuroimaging/extractors/tests/test_nifti1.py
+++ b/datalad_neuroimaging/extractors/tests/test_nifti1.py
@@ -39,7 +39,7 @@ target = {
     "datatype": "int16",
     "dim": [4, 91, 109, 91, 2, 1, 1, 1],
     "pixdim": [-1.0, 2.0, 2.0, 2.0, 6.0, 1.0, 1.0, 1.0],
-    "xyz_unit": "millimiter (uo:0000016)",
+    "xyz_unit": "millimeter (uo:0000016)",
     "t_unit": "second (uo:0000010)",
     "cal_min": 3000.0,
     "cal_max": 8000.0,

--- a/datalad_neuroimaging/tests/test_search.py
+++ b/datalad_neuroimaging/tests/test_search.py
@@ -52,14 +52,14 @@ except (ImportError, SkipTest):
 @known_failure_osx
 @with_tempfile
 def test_our_metadataset_search(tdir=None):
-    # TODO renable when a dataset with new aggregated metadata is
+    # TODO re-enable when a dataset with new aggregated metadata is
     # available at some public location
     raise SkipTest
     # smoke test for basic search operations on our super-megadataset
     # expensive operation but ok
     #ds = install(
     #    path=tdir,
-    #    # TODO renable test when /// metadata actually conforms to the new metadata
+    #    # TODO re-enable test when /// metadata actually conforms to the new metadata
     #    #source="///",
     #    source="smaug:/mnt/btrfs/datasets-meta6-4/datalad/crawl",
     #    result_xfm='datasets', return_type='item-or-list')

--- a/formatters.py
+++ b/formatters.py
@@ -75,7 +75,7 @@ class ManPageFormatter(argparse.HelpFormatter):
 
     def _make_name(self, parser):
         """
-        this method is in consitent with others ... it relies on
+        this method is in consistent with others ... it relies on
         distribution
         """
         return '.SH NAME\n%s \\- %s\n' % (parser.prog,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,9 @@
 [build-system]
 requires = ["setuptools >= 43.0.0", "wheel"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,versioneer.py'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
Strangely codespell didn't pick up `millimiter` in some files :-/