### PR TITLE
BF: Explicitly cast to simple float from numpy.float32 which is now returned by smth (nibabel?)

### DIFF
--- a/changelog.d/pr-134.md
+++ b/changelog.d/pr-134.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: Explicitly cast to simple float from numpy.float32 which is now returned by smth (nibabel?).  [PR #134](https://github.com/datalad/datalad-neuroimaging/pull/134) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad_neuroimaging/extractors/nifti1.py
+++ b/datalad_neuroimaging/extractors/nifti1.py
@@ -179,7 +179,7 @@ class MetadataExtractor(BaseMetadataExtractor):
                     spatial_unit))
             # TODO does not see the light of day
             meta['spatial_resolution(mm)'] = \
-                [(i * spatial_unit_conversion) for i in header.get_zooms()[:3]]
+                [(float(i * spatial_unit_conversion)) for i in header.get_zooms()[:3]]
             # time
             if len(header.get_zooms()) > 3:
                 # got a 4th dimension
@@ -194,7 +194,7 @@ class MetadataExtractor(BaseMetadataExtractor):
                     'micron': 0.000001}.get(rts_unit, 1.0)
                 if rts_unit not in ('hz', 'ppm', 'rads'):
                     meta['temporal_spacing(s)'] = \
-                        header.get_zooms()[3] * rts_unit_conversion
+                        float(header.get_zooms()[3] * rts_unit_conversion)
 
             contentmeta.append((f, meta))
 


### PR DESCRIPTION
Should address failures observed in datalad-extensions testing so I will mark for release if passes