### PR TITLE
BF: Fix deprecated RunProcedure import in test_procedure

### DIFF
--- a/changelog.d/pr-140.md
+++ b/changelog.d/pr-140.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: Fix deprecated RunProcedure import in test_procedure.  [PR #140](https://github.com/datalad/datalad-neuroimaging/pull/140) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad_neuroimaging/tests/test_procedure.py
+++ b/datalad_neuroimaging/tests/test_procedure.py
@@ -1,4 +1,4 @@
-import datalad.interface.run_procedure
+import datalad.local.run_procedure
 from datalad.distribution.dataset import Dataset
 from datalad.tests.utils_pytest import (
     eq_,


### PR DESCRIPTION
datalad.interface.run_procedure was deprecated in 0.16.0, moved to datalad.local.run_procedure.

not sure why didn't trigger in prior testing :-/